### PR TITLE
Add multi-line details field to checklist items. Show note timestamps.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,8 +72,8 @@ extensions.configure<ApplicationExtension>("android") {
         applicationId = rememberApplicationId
         minSdk = 31
         targetSdk = 37
-        versionCode = 102
-        versionName = "1.0.2"
+        versionCode = 103
+        versionName = "1.0.3"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }
     }

--- a/app/schemas/dev.bikram.remember.data.RememberDatabase/3.json
+++ b/app/schemas/dev.bikram.remember.data.RememberDatabase/3.json
@@ -1,0 +1,523 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "6600599e8fb6bdf439676899ddc93fb4",
+    "entities": [
+      {
+        "tableName": "notes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `kind` TEXT NOT NULL, `title` TEXT NOT NULL, `body` TEXT NOT NULL, `checklistText` TEXT NOT NULL, `attachmentText` TEXT NOT NULL, `actionsText` TEXT NOT NULL, `colorIndex` INTEGER NOT NULL, `starred` INTEGER NOT NULL, `trashed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `reminderAt` INTEGER, `importance` TEXT NOT NULL, `visibility` TEXT NOT NULL, `pictureUri` TEXT, `pictureHeroFraming` TEXT, `locked` INTEGER NOT NULL, `iconKey` TEXT, `actions` TEXT NOT NULL, `tags` TEXT NOT NULL, `recurrence` TEXT, `archived` INTEGER NOT NULL, `trashedAt` INTEGER, `completedAt` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checklistText",
+            "columnName": "checklistText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attachmentText",
+            "columnName": "attachmentText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionsText",
+            "columnName": "actionsText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorIndex",
+            "columnName": "colorIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "starred",
+            "columnName": "starred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trashed",
+            "columnName": "trashed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reminderAt",
+            "columnName": "reminderAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "importance",
+            "columnName": "importance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "visibility",
+            "columnName": "visibility",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pictureUri",
+            "columnName": "pictureUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pictureHeroFraming",
+            "columnName": "pictureHeroFraming",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "locked",
+            "columnName": "locked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconKey",
+            "columnName": "iconKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "actions",
+            "columnName": "actions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recurrence",
+            "columnName": "recurrence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "archived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trashedAt",
+            "columnName": "trashedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "checklist_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `noteId` INTEGER NOT NULL, `text` TEXT NOT NULL, `checked` INTEGER NOT NULL, `sortOrder` REAL NOT NULL, `parentId` INTEGER, `depth` INTEGER NOT NULL, `details` TEXT NOT NULL, FOREIGN KEY(`noteId`) REFERENCES `notes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noteId",
+            "columnName": "noteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checked",
+            "columnName": "checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "depth",
+            "columnName": "depth",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "details",
+            "columnName": "details",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_checklist_items_noteId",
+            "unique": false,
+            "columnNames": [
+              "noteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_checklist_items_noteId` ON `${TABLE_NAME}` (`noteId`)"
+          },
+          {
+            "name": "index_checklist_items_parentId",
+            "unique": false,
+            "columnNames": [
+              "parentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_checklist_items_parentId` ON `${TABLE_NAME}` (`parentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "notes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "noteId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "attachments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `noteId` INTEGER NOT NULL, `uri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `mimeType` TEXT, FOREIGN KEY(`noteId`) REFERENCES `notes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noteId",
+            "columnName": "noteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_attachments_noteId",
+            "unique": false,
+            "columnNames": [
+              "noteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_attachments_noteId` ON `${TABLE_NAME}` (`noteId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "notes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "noteId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "notes_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`title` TEXT NOT NULL, `body` TEXT NOT NULL, `tags` TEXT NOT NULL, `checklistText` TEXT NOT NULL, `attachmentText` TEXT NOT NULL, `actionsText` TEXT NOT NULL, tokenize=unicode61 `remove_diacritics=2`, content=`notes`)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checklistText",
+            "columnName": "checklistText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attachmentText",
+            "columnName": "attachmentText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionsText",
+            "columnName": "actionsText",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [
+            "remove_diacritics=2"
+          ],
+          "contentTable": "notes",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_notes_fts_BEFORE_UPDATE BEFORE UPDATE ON `notes` BEGIN DELETE FROM `notes_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_notes_fts_BEFORE_DELETE BEFORE DELETE ON `notes` BEGIN DELETE FROM `notes_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_notes_fts_AFTER_UPDATE AFTER UPDATE ON `notes` BEGIN INSERT INTO `notes_fts`(`docid`, `title`, `body`, `tags`, `checklistText`, `attachmentText`, `actionsText`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`body`, NEW.`tags`, NEW.`checklistText`, NEW.`attachmentText`, NEW.`actionsText`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_notes_fts_AFTER_INSERT AFTER INSERT ON `notes` BEGIN INSERT INTO `notes_fts`(`docid`, `title`, `body`, `tags`, `checklistText`, `attachmentText`, `actionsText`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`body`, NEW.`tags`, NEW.`checklistText`, NEW.`attachmentText`, NEW.`actionsText`); END"
+        ]
+      },
+      {
+        "tableName": "tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `normalizedName` TEXT NOT NULL, `colorHex` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedName",
+            "columnName": "normalizedName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorHex",
+            "columnName": "colorHex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tags_normalizedName",
+            "unique": true,
+            "columnNames": [
+              "normalizedName"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tags_normalizedName` ON `${TABLE_NAME}` (`normalizedName`)"
+          }
+        ]
+      },
+      {
+        "tableName": "note_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`noteId` INTEGER NOT NULL, `tagId` INTEGER NOT NULL, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`noteId`, `tagId`), FOREIGN KEY(`noteId`) REFERENCES `notes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tagId`) REFERENCES `tags`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "noteId",
+            "columnName": "noteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tagId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "noteId",
+            "tagId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_note_tags_noteId",
+            "unique": false,
+            "columnNames": [
+              "noteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_tags_noteId` ON `${TABLE_NAME}` (`noteId`)"
+          },
+          {
+            "name": "index_note_tags_tagId",
+            "unique": false,
+            "columnNames": [
+              "tagId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_tags_tagId` ON `${TABLE_NAME}` (`tagId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "notes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "noteId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "tags",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tagId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6600599e8fb6bdf439676899ddc93fb4')"
+    ]
+  }
+}

--- a/app/src/main/java/dev/bikram/remember/data/BackupIo.kt
+++ b/app/src/main/java/dev/bikram/remember/data/BackupIo.kt
@@ -146,6 +146,7 @@ class BackupIo(
                             JSONObject().apply {
                                 put("id", it2.id)
                                 put("text", it2.text)
+                                put("details", it2.details)
                                 put("checked", it2.checked)
                                 put("sortOrder", it2.sortOrder)
                                 it2.parentId?.let { parent -> put("parentId", parent) }
@@ -737,6 +738,7 @@ class BackupIo(
                 id = jo.optLong("id", 0L),
                 noteId = 0L,
                 text = jo.optString("text", ""),
+                details = jo.optString("details", ""),
                 checked = jo.optBoolean("checked", false),
                 sortOrder = sortOrder,
                 parentId = parentId,
@@ -813,7 +815,7 @@ class BackupIo(
     private fun JSONObject.optStringOrNull(key: String): String? = if (has(key) && !isNull(key)) getString(key) else null
 
     companion object {
-        const val SCHEMA_VERSION = 2
+        const val SCHEMA_VERSION = 3
         const val LEGACY_SCHEMA_VERSION = 1
         const val ENTRY_MANIFEST = "backup_manifest.json"
         const val ENTRY_NOTES = "notes.json"

--- a/app/src/main/java/dev/bikram/remember/data/Entities.kt
+++ b/app/src/main/java/dev/bikram/remember/data/Entities.kt
@@ -234,6 +234,7 @@ data class ChecklistItemEntity(
     val parentId: Long? = null,
     /** 0 for top-level rows, 1 for children. Kept in sync with [parentId] presence. */
     val depth: Int = 0,
+    val details: String = "",
 )
 
 @Entity(

--- a/app/src/main/java/dev/bikram/remember/data/NoteRepository.kt
+++ b/app/src/main/java/dev/bikram/remember/data/NoteRepository.kt
@@ -41,6 +41,7 @@ data class PersistableChecklistItem(
     val sortOrder: Double,
     val parentLocalKey: Long? = null,
     val depth: Int = 0,
+    val details: String = "",
 )
 
 /**
@@ -239,6 +240,7 @@ class NoteRepository(
                     ChecklistItemEntity(
                         noteId = id,
                         text = text,
+                        details = "",
                         checked = false,
                         sortOrder = (index + 1).toDouble(),
                         parentId = null,
@@ -247,6 +249,56 @@ class NoteRepository(
                 },
             )
         }
+        if (options.reminderAt != null) {
+            val createdNoteWithItems = noteDao.get(id)
+            if (createdNoteWithItems != null) {
+                scheduler?.scheduleOrShow(createdNoteWithItems.note, createdNoteWithItems.items)
+            }
+        }
+        postWriteBookkeeping()
+        return id
+    }
+
+    suspend fun createListWithItems(
+        title: String,
+        colorIndex: Int,
+        items: List<PersistableChecklistItem>,
+        options: NoteOptions = NoteOptions(),
+    ): Long {
+        val now = clock()
+        val validItems = items.filter { item -> item.text.isNotBlank() || item.details.isNotBlank() }
+        val id =
+            noteDao.insert(
+                NoteEntity(
+                    kind = NoteKind.LIST,
+                    title = title,
+                    body = "",
+                    checklistText =
+                        checklistSearchText(
+                            validItems
+                                .sortedBy { item -> item.sortOrder }
+                                .flatMap { item -> listOf(item.text, item.details) },
+                        ),
+                    colorIndex = colorIndex,
+                    starred = false,
+                    trashed = false,
+                    createdAt = now,
+                    updatedAt = now,
+                    reminderAt = options.reminderAt,
+                    importance = options.importance,
+                    visibility = options.visibility,
+                    pictureUri = options.pictureUri,
+                    pictureHeroFraming = options.pictureHeroFraming,
+                    locked = options.locked,
+                    iconKey = options.iconKey,
+                    actions = options.actions,
+                    actionsText = actionsSearchText(options.actions),
+                    tags = options.tags,
+                    recurrence = options.recurrence?.sanitized(),
+                ),
+            )
+        tagRepository?.replaceTagsForNote(id, options.tags)
+        persistHierarchy(noteId = id, items = validItems)
         if (options.reminderAt != null) {
             val createdNoteWithItems = noteDao.get(id)
             if (createdNoteWithItems != null) {
@@ -320,7 +372,7 @@ class NoteRepository(
                             checklistSearchText(
                                 items
                                     .sortedBy { item -> item.sortOrder }
-                                    .map { item -> item.text },
+                                    .flatMap { item -> listOf(item.text, item.details) },
                             ),
                         updatedAt = clock(),
                         reminderAt = options.reminderAt,
@@ -741,7 +793,7 @@ class NoteRepository(
                         checklistSearchText(
                             items
                                 .sortedBy { item -> item.sortOrder }
-                                .map { item -> item.text },
+                                .flatMap { item -> listOf(item.text, item.details) },
                         ),
                     attachmentText = attachmentSearchText(attachments),
                     actionsText = actionsSearchText(note.actions),
@@ -760,6 +812,7 @@ class NoteRepository(
                         PersistableChecklistItem(
                             localKey = item.id,
                             text = item.text,
+                            details = item.details,
                             checked = item.checked,
                             sortOrder = item.sortOrder,
                             parentLocalKey = item.parentId,
@@ -807,6 +860,7 @@ class NoteRepository(
                         id = 0,
                         noteId = noteId,
                         text = draft.text,
+                        details = draft.details,
                         checked = draft.checked,
                         sortOrder = draft.sortOrder,
                         parentId = null,
@@ -826,6 +880,7 @@ class NoteRepository(
                         id = 0,
                         noteId = noteId,
                         text = draft.text,
+                        details = draft.details,
                         checked = draft.checked,
                         sortOrder = draft.sortOrder,
                         parentId = realParentId,
@@ -856,6 +911,7 @@ class NoteRepository(
                         id = existing.id,
                         noteId = noteId,
                         text = draft.text,
+                        details = draft.details,
                         checked = draft.checked,
                         sortOrder = draft.sortOrder,
                         parentId = null,
@@ -870,6 +926,7 @@ class NoteRepository(
                             id = 0,
                             noteId = noteId,
                             text = draft.text,
+                            details = draft.details,
                             checked = draft.checked,
                             sortOrder = draft.sortOrder,
                             parentId = null,
@@ -892,6 +949,7 @@ class NoteRepository(
                         id = existing.id,
                         noteId = noteId,
                         text = draft.text,
+                        details = draft.details,
                         checked = draft.checked,
                         sortOrder = draft.sortOrder,
                         parentId = realParentId,
@@ -906,6 +964,7 @@ class NoteRepository(
                             id = 0,
                             noteId = noteId,
                             text = draft.text,
+                            details = draft.details,
                             checked = draft.checked,
                             sortOrder = draft.sortOrder,
                             parentId = realParentId,

--- a/app/src/main/java/dev/bikram/remember/data/RememberDatabase.kt
+++ b/app/src/main/java/dev/bikram/remember/data/RememberDatabase.kt
@@ -65,7 +65,7 @@ class Converters {
         TagEntity::class,
         NoteTagCrossRef::class,
     ],
-    version = 2,
+    version = 3,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)
@@ -82,7 +82,7 @@ abstract class RememberDatabase : RoomDatabase() {
         fun build(context: Context): RememberDatabase =
             Room
                 .databaseBuilder(context, RememberDatabase::class.java, "remember.db")
-                .addMigrations(MIGRATION_1_2)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
                 .fallbackToDestructiveMigration(false)
                 .build()
 
@@ -148,6 +148,13 @@ abstract class RememberDatabase : RoomDatabase() {
                         SELECT rowid, title, body, tags, checklistText, attachmentText, actionsText FROM notes
                         """.trimIndent(),
                     )
+                }
+            }
+
+        private val MIGRATION_2_3 =
+            object : Migration(2, 3) {
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL("ALTER TABLE checklist_items ADD COLUMN details TEXT NOT NULL DEFAULT ''")
                 }
             }
 

--- a/app/src/main/java/dev/bikram/remember/domain/checklist/ChecklistEditor.kt
+++ b/app/src/main/java/dev/bikram/remember/domain/checklist/ChecklistEditor.kt
@@ -13,6 +13,7 @@ data class EditableItem(
     val sortOrder: Double,
     val parentLocalId: Long? = null,
     val depth: Int = 0,
+    val details: String = "",
 )
 
 data class ChecklistEditResult(

--- a/app/src/main/java/dev/bikram/remember/googletasks/GoogleTasksImporter.kt
+++ b/app/src/main/java/dev/bikram/remember/googletasks/GoogleTasksImporter.kt
@@ -2,6 +2,7 @@ package dev.bikram.remember.googletasks
 
 import dev.bikram.remember.data.NoteOptions
 import dev.bikram.remember.data.NoteRepository
+import dev.bikram.remember.data.PersistableChecklistItem
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -15,7 +16,7 @@ import java.time.format.DateTimeFormatter
  * Mapping rules (one note per task is the default; group-by-list and list-as-checklist are
  * driven by [ImportMode]):
  *  - title  -> NoteEntity.title (falls back to the first line of `notes` when title is blank)
- *  - notes  -> NoteEntity.body
+ *  - notes  -> NoteEntity.body, or checklist item details in list-as-checklist mode
  *  - status == "completed" -> NoteEntity.completedAt (uses the API-provided completion timestamp
  *    when present, otherwise [now])
  *  - due (date-only per Google's docs) -> reminderAt at 09:00 in [zone]
@@ -87,30 +88,48 @@ class GoogleTasksImporter(
                         group
                             .filter { it.task.parent.isNullOrBlank() }
                             .sortedBy { it.task.position.orEmpty() }
-                    val itemTexts = mutableListOf<String>()
+                    val checklistItems = mutableListOf<PersistableChecklistItem>()
+                    var nextLocalKey = -1L
+                    var sortOrder = 1.0
                     parents.forEach { parent ->
-                        itemTexts.add(
-                            parent.task.title
-                                .orEmpty()
-                                .ifBlank { firstLineOfNotes(parent.task) },
-                        )
+                        val parentTitle = checklistItemTitle(parent.task)
+                        val parentLocalKey = nextLocalKey--
+                        if (parentTitle.isNotBlank()) {
+                            checklistItems.add(
+                                PersistableChecklistItem(
+                                    localKey = parentLocalKey,
+                                    text = parentTitle,
+                                    details = checklistItemDetails(parent.task),
+                                    checked = isCompleted(parent.task),
+                                    sortOrder = sortOrder++,
+                                ),
+                            )
+                        }
                         group
                             .filter { it.task.parent == parent.task.id }
                             .sortedBy { it.task.position.orEmpty() }
                             .forEach { child ->
-                                itemTexts.add(
-                                    "- " +
-                                        child.task.title
-                                            .orEmpty()
-                                            .ifBlank { firstLineOfNotes(child.task) },
-                                )
+                                val childTitle = checklistItemTitle(child.task)
+                                if (childTitle.isNotBlank()) {
+                                    checklistItems.add(
+                                        PersistableChecklistItem(
+                                            localKey = nextLocalKey--,
+                                            text = childTitle,
+                                            details = checklistItemDetails(child.task),
+                                            checked = isCompleted(child.task),
+                                            sortOrder = sortOrder++,
+                                            parentLocalKey = parentLocalKey.takeIf { parentTitle.isNotBlank() },
+                                            depth = if (parentTitle.isNotBlank()) 1 else 0,
+                                        ),
+                                    )
+                                }
                             }
                     }
                     val newId =
-                        repository.createList(
+                        repository.createListWithItems(
                             title = taskListTitle,
                             colorIndex = 0,
-                            items = itemTexts.filter { it.isNotBlank() },
+                            items = checklistItems,
                             options = NoteOptions(tags = listOf(taskListTitle)),
                         )
                     group.forEach {
@@ -139,6 +158,7 @@ class GoogleTasksImporter(
                                             .ifBlank { firstLineOfNotes(wrapper.task) }
                                     if (displayTitle.isNotBlank()) {
                                         append(indent)
+                                            .append("- ")
                                             .append(mark)
                                             .append(' ')
                                             .append(displayTitle)
@@ -149,7 +169,10 @@ class GoogleTasksImporter(
                                             .orEmpty()
                                             .isNotBlank()
                                     ) {
-                                        append(indent).append("    ").append(wrapper.task.notes.replace("\n", "\n    ")).append('\n')
+                                        append(indent)
+                                            .append("    ")
+                                            .append(wrapper.task.notes.replace("\n", "\n$indent    "))
+                                            .append('\n')
                                     }
                                 }
                         }.trimEnd()
@@ -258,6 +281,24 @@ class GoogleTasksImporter(
             .firstOrNull { it.isNotBlank() }
             ?.trim()
             .orEmpty()
+
+    private fun checklistItemTitle(task: GoogleTask): String =
+        task.title
+            .orEmpty()
+            .trim()
+            .ifBlank { firstLineOfNotes(task) }
+
+    private fun checklistItemDetails(task: GoogleTask): String {
+        val notes = task.notes.orEmpty().trim()
+        if (notes.isBlank()) return ""
+        if (task.title.orEmpty().isNotBlank()) return notes
+        return notes
+            .lineSequence()
+            .dropWhile { line -> line.isBlank() }
+            .drop(1)
+            .joinToString("\n")
+            .trim()
+    }
 
     private fun isCompleted(task: GoogleTask): Boolean = task.status.equals(GoogleTaskStatus.COMPLETED, ignoreCase = true)
 

--- a/app/src/main/java/dev/bikram/remember/ui/common/MarkdownText.kt
+++ b/app/src/main/java/dev/bikram/remember/ui/common/MarkdownText.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.unit.dp
 import dev.bikram.remember.ui.feedback.tapSoundClickable
 
 private val MarkdownLinkRegex = Regex("""\[([^\]]+)]\(([^)]+)\)""")
+private val MarkdownChecklistContinuationLineRegex = Regex("""^\s{4,}(.+)$""")
 
 internal data class MarkdownTextTap(
     val markdownOffset: Int,
@@ -142,10 +143,33 @@ internal fun MarkdownText(
                     onTextLongPress = onTextLongPress,
                 )
             } else {
+                val checklistContinuationLines =
+                    if (MarkdownChecklistLineRegex.matchEntire(lines[lineIndex]) != null) {
+                        val continuationLines = mutableListOf<MarkdownContinuationLine>()
+                        var continuationIndex = lineIndex + 1
+                        while (continuationIndex < lines.size) {
+                            val continuationLine = lines[continuationIndex]
+                            val continuationMatch =
+                                MarkdownChecklistContinuationLineRegex.matchEntire(continuationLine) ?: break
+                            if (isMarkdownBlockLine(continuationLine)) break
+                            val contentRange = continuationMatch.groups[1]?.range ?: break
+                            continuationLines +=
+                                MarkdownContinuationLine(
+                                    text = continuationMatch.groupValues[1],
+                                    lineStartOffset = lineStartOffsets.getOrElse(continuationIndex) { markdown.length },
+                                    contentStartOffset = contentRange.first,
+                                )
+                            continuationIndex++
+                        }
+                        continuationLines
+                    } else {
+                        emptyList()
+                    }
                 MarkdownLine(
                     line = lines[lineIndex],
                     lineIndex = lineIndex,
                     lineStartOffset = lineStartOffsets.getOrElse(lineIndex) { markdown.length },
+                    checklistContinuationLines = checklistContinuationLines,
                     style = style,
                     styler = styler,
                     includeLinkAnnotations = includeLinkAnnotations,
@@ -155,17 +179,32 @@ internal fun MarkdownText(
                     onLinkClick = onLinkClick,
                     onLinkLongPress = onLinkLongPress,
                 )
-                lineIndex++
+                lineIndex += 1 + checklistContinuationLines.size
             }
         }
     }
 }
+
+private data class MarkdownContinuationLine(
+    val text: String,
+    val lineStartOffset: Int,
+    val contentStartOffset: Int,
+)
+
+private fun isMarkdownBlockLine(line: String): Boolean =
+    MarkdownHeadingLineRegex.matchEntire(line) != null ||
+        MarkdownChecklistLineRegex.matchEntire(line) != null ||
+        MarkdownBulletLineRegex.matchEntire(line) != null ||
+        MarkdownNumberedLineRegex.matchEntire(line) != null ||
+        MarkdownQuoteLineRegex.matchEntire(line) != null ||
+        MarkdownCodeFenceLineRegex.matches(line)
 
 @Composable
 private fun MarkdownLine(
     line: String,
     lineIndex: Int,
     lineStartOffset: Int,
+    checklistContinuationLines: List<MarkdownContinuationLine>,
     style: TextStyle,
     styler: MarkdownStyler,
     includeLinkAnnotations: Boolean,
@@ -202,7 +241,7 @@ private fun MarkdownLine(
         val checked = checklistMatch.groupValues[2].equals("x", ignoreCase = true)
         Row(
             modifier = Modifier.padding(start = styler.listStartPadding(checklistMatch.groupValues[1], baseIndent = 0.dp)),
-            verticalAlignment = Alignment.CenterVertically,
+            verticalAlignment = Alignment.Top,
         ) {
             RememberMaterialRoundedSymbol(
                 name = if (checked) "check_box" else "check_box_outline_blank",
@@ -219,21 +258,43 @@ private fun MarkdownLine(
             )
             Spacer(Modifier.width(8.dp))
             val contentRange = checklistMatch.groups[3]?.range
-            MarkdownInlineText(
-                text =
-                    styler.markdownInlineAnnotatedString(
-                        source = checklistMatch.groupValues[3],
-                        includeLinkAnnotations = includeLinkAnnotations,
-                    ),
-                style = if (checked) style.copy(textDecoration = TextDecoration.LineThrough) else style,
+            Column(
                 modifier = Modifier.weight(1f),
-                source = checklistMatch.groupValues[3],
-                sourceOffset = lineStartOffset + (contentRange?.first ?: 0),
-                onTextTap = onTextTap,
-                onTextLongPress = onTextLongPress,
-                onLinkClick = onLinkClick,
-                onLinkLongPress = onLinkLongPress,
-            )
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                MarkdownInlineText(
+                    text =
+                        styler.markdownInlineAnnotatedString(
+                            source = checklistMatch.groupValues[3],
+                            includeLinkAnnotations = includeLinkAnnotations,
+                        ),
+                    style = if (checked) style.copy(textDecoration = TextDecoration.LineThrough) else style,
+                    modifier = Modifier.fillMaxWidth(),
+                    source = checklistMatch.groupValues[3],
+                    sourceOffset = lineStartOffset + (contentRange?.first ?: 0),
+                    onTextTap = onTextTap,
+                    onTextLongPress = onTextLongPress,
+                    onLinkClick = onLinkClick,
+                    onLinkLongPress = onLinkLongPress,
+                )
+                checklistContinuationLines.forEach { continuationLine ->
+                    MarkdownInlineText(
+                        text =
+                            styler.markdownInlineAnnotatedString(
+                                source = continuationLine.text,
+                                includeLinkAnnotations = includeLinkAnnotations,
+                            ),
+                        style = style,
+                        modifier = Modifier.fillMaxWidth(),
+                        source = continuationLine.text,
+                        sourceOffset = continuationLine.lineStartOffset + continuationLine.contentStartOffset,
+                        onTextTap = onTextTap,
+                        onTextLongPress = onTextLongPress,
+                        onLinkClick = onLinkClick,
+                        onLinkLongPress = onLinkLongPress,
+                    )
+                }
+            }
         }
         return
     }

--- a/app/src/main/java/dev/bikram/remember/ui/components/NoteCard.kt
+++ b/app/src/main/java/dev/bikram/remember/ui/components/NoteCard.kt
@@ -738,25 +738,46 @@ private fun ChecklistPreview(
     }
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         items.forEach { item ->
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                // Indent children one gutter's width to mirror the editor hierarchy.
-                if (item.depth > 0) Spacer(Modifier.width(16.dp))
-                RememberMaterialRoundedSymbol(
-                    name = if (item.checked) "check_circle" else "radio_button_unchecked",
-                    size = 16.dp,
-                    tint = contentColor,
-                    weight = FontWeight.Medium,
-                    modifier = Modifier.alpha(if (item.checked) 0.6f else 0.85f),
-                )
-                Spacer(Modifier.width(10.dp))
-                Text(
-                    text = item.text,
-                    style = MaterialTheme.typography.bodyMedium.copy(color = contentColor),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    textDecoration = if (item.checked) TextDecoration.LineThrough else TextDecoration.None,
-                    modifier = Modifier.alpha(if (item.checked) 0.55f else 0.92f),
-                )
+            Column {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    // Indent children one gutter's width to mirror the editor hierarchy.
+                    if (item.depth > 0) Spacer(Modifier.width(16.dp))
+                    RememberMaterialRoundedSymbol(
+                        name = if (item.checked) "check_circle" else "radio_button_unchecked",
+                        size = 16.dp,
+                        tint = contentColor,
+                        weight = FontWeight.Medium,
+                        modifier = Modifier.alpha(if (item.checked) 0.6f else 0.85f),
+                    )
+                    Spacer(Modifier.width(10.dp))
+                    Text(
+                        text = item.text,
+                        style = MaterialTheme.typography.bodyMedium.copy(color = contentColor),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        textDecoration = if (item.checked) TextDecoration.LineThrough else TextDecoration.None,
+                        modifier = Modifier.alpha(if (item.checked) 0.55f else 0.92f),
+                    )
+                }
+                val detailPreview =
+                    item.details
+                        .lineSequence()
+                        .firstOrNull { line -> line.isNotBlank() }
+                        ?.trim()
+                        .orEmpty()
+                if (detailPreview.isNotBlank()) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        if (item.depth > 0) Spacer(Modifier.width(16.dp))
+                        Spacer(Modifier.width(26.dp))
+                        Text(
+                            text = detailPreview,
+                            style = MaterialTheme.typography.bodySmall.copy(color = contentColor),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.alpha(if (item.checked) 0.42f else 0.62f),
+                        )
+                    }
+                }
             }
         }
         if (hiddenCount > 0) {

--- a/app/src/main/java/dev/bikram/remember/ui/components/NoteCardUiModel.kt
+++ b/app/src/main/java/dev/bikram/remember/ui/components/NoteCardUiModel.kt
@@ -32,6 +32,7 @@ data class NoteCardUiModel(
 @Immutable
 data class NoteCardChecklistItemUiModel(
     val text: String,
+    val details: String,
     val checked: Boolean,
     val depth: Int,
 )
@@ -63,6 +64,7 @@ fun NoteWithItems.toNoteCardUiModel(
                 .map { item ->
                     NoteCardChecklistItemUiModel(
                         text = item.text,
+                        details = item.details,
                         checked = item.checked,
                         depth = item.depth,
                     )

--- a/app/src/main/java/dev/bikram/remember/ui/edit/ChecklistRendering.kt
+++ b/app/src/main/java/dev/bikram/remember/ui/edit/ChecklistRendering.kt
@@ -2,7 +2,9 @@ package dev.bikram.remember.ui.edit
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,6 +17,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -28,7 +34,10 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.LayoutDirection
@@ -95,6 +104,11 @@ internal fun ChecklistRow(
     item: EditableItem,
     isEditMode: Boolean,
     focusRequester: androidx.compose.ui.focus.FocusRequester? = null,
+    detailsFocusRequester: androidx.compose.ui.focus.FocusRequester? = null,
+    initialTitleSelection: Int? = null,
+    initialDetailsSelection: Int? = null,
+    onTitleFocusOffsetConsumed: () -> Unit = {},
+    onDetailsFocusOffsetConsumed: () -> Unit = {},
     isDragging: Boolean = false,
     dragHandleModifier: Modifier = Modifier,
     /**
@@ -104,10 +118,12 @@ internal fun ChecklistRow(
      */
     showDragHandle: Boolean = true,
     onTextChange: (String) -> Unit,
+    onDetailsChange: (String) -> Unit = {},
     onToggle: () -> Unit,
     onRemove: () -> Unit,
     onNext: () -> Unit = {},
-    onTextTap: (() -> Unit)? = null,
+    onTextTap: ((Int) -> Unit)? = null,
+    onDetailsTap: ((Int) -> Unit)? = null,
     /**
      * Horizontal drag callback. `+1` means the user dragged right past the indent threshold
      * (request to nest under the previous top-level sibling). `-1` means the user dragged left
@@ -129,6 +145,41 @@ internal fun ChecklistRow(
         .animateDpAsState(depthIndent, label = "checklistDepthIndent")
 
     val haptic = LocalHapticFeedback.current
+    var detailsExpanded by rememberSaveable(item.localId) { mutableStateOf(false) }
+
+    var titleFieldValue by remember(item.text) {
+        mutableStateOf(TextFieldValue(text = item.text, selection = TextRange(item.text.length)))
+    }
+    var detailsFieldValue by remember(item.details) {
+        mutableStateOf(TextFieldValue(text = item.details, selection = TextRange(item.details.length)))
+    }
+
+    LaunchedEffect(isEditMode, initialTitleSelection) {
+        if (isEditMode && initialTitleSelection != null) {
+            val clamped = initialTitleSelection.coerceIn(0, item.text.length)
+            titleFieldValue = titleFieldValue.copy(selection = TextRange(clamped))
+            onTitleFocusOffsetConsumed()
+        }
+    }
+
+    LaunchedEffect(isEditMode, initialDetailsSelection) {
+        if (isEditMode && initialDetailsSelection != null) {
+            val clamped = initialDetailsSelection.coerceIn(0, item.details.length)
+            detailsFieldValue = detailsFieldValue.copy(selection = TextRange(clamped))
+            onDetailsFocusOffsetConsumed()
+        }
+    }
+
+    val detailLineCount = item.details.lineSequence().count { it.isNotBlank() }
+    val detailsCanExpand = detailLineCount > 1
+    val showDetailsAffordance = isEditMode || detailsCanExpand
+    val detailPreview =
+        item.details
+            .lineSequence()
+            .firstOrNull { it.isNotBlank() }
+            ?.trim()
+            .orEmpty()
+    val detailsToggleLabel = stringResource(R.string.edit_list_item_details_placeholder)
 
     LaunchedEffect(isDragging) {
         if (isDragging) {
@@ -192,8 +243,7 @@ internal fun ChecklistRow(
             Modifier
         }
 
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
+    Column(
         modifier =
             modifier
                 .fillMaxWidth()
@@ -202,115 +252,248 @@ internal fun ChecklistRow(
                 .scale(scale)
                 .alpha(alpha),
     ) {
-        if (isEditMode && showDragHandle) {
-            // The drag handle is a vertical-only gesture surface: only `dragHandleModifier`
-            // (the library's `draggableHandle()`) is applied here. We deliberately do NOT also
-            // attach the horizontal indentModifier to this Box because detectHorizontalDragGestures
-            // and draggableHandle() live on independent pointer-input blocks and both observe
-            // the same pointer stream. During a long vertical reorder drag the user's finger
-            // tends to drift horizontally by small amounts; that drift can accumulate past the
-            // indent threshold and silently reparent the item, which then breaks the parent
-            // cascade in `toggleChecked` (a child's parentLocalId no longer matches the tapped
-            // parent, or the parent itself ends up at depth 1 and the `target.depth == 0`
-            // cascade branch is skipped). The row body retains the horizontal indent gesture,
-            // so users can still swipe the text area left or right to change depth.
-            val cdReorder = stringResource(R.string.cd_reorder_drag_handle)
-            Box(
-                modifier =
-                    dragHandleModifier
-                        .padding(start = 4.dp, end = 4.dp)
-                        .size(32.dp)
-                        .semantics { contentDescription = cdReorder },
-                contentAlignment = Alignment.Center,
-            ) {
-                RememberMaterialRoundedSymbol(
-                    name = "drag_indicator",
-                    size = 20.dp,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    weight = FontWeight.Medium,
-                )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            if (isEditMode && showDragHandle) {
+                // The drag handle is a vertical-only gesture surface: only `dragHandleModifier`
+                // (the library's `draggableHandle()`) is applied here. We deliberately do NOT also
+                // attach the horizontal indentModifier to this Box because detectHorizontalDragGestures
+                // and draggableHandle() live on independent pointer-input blocks and both observe
+                // the same pointer stream. During a long vertical reorder drag the user's finger
+                // tends to drift horizontally by small amounts; that drift can accumulate past the
+                // indent threshold and silently reparent the item, which then breaks the parent
+                // cascade in `toggleChecked` (a child's parentLocalId no longer matches the tapped
+                // parent, or the parent itself ends up at depth 1 and the `target.depth == 0`
+                // cascade branch is skipped). The row body retains the horizontal indent gesture,
+                // so users can still swipe the text area left or right to change depth.
+                val cdReorder = stringResource(R.string.cd_reorder_drag_handle)
+                Box(
+                    modifier =
+                        dragHandleModifier
+                            .padding(start = 4.dp, end = 4.dp)
+                            .size(32.dp)
+                            .semantics { contentDescription = cdReorder },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    RememberMaterialRoundedSymbol(
+                        name = "drag_indicator",
+                        size = 20.dp,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        weight = FontWeight.Medium,
+                    )
+                }
             }
-        }
-        RememberIconButton(onClick = onToggle) {
-            RememberMaterialRoundedSymbol(
-                name = if (item.checked) "check_box" else "check_box_outline_blank",
-                size = 24.dp,
-                tint = if (item.checked) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
-                weight = FontWeight.Medium,
-            )
-        }
-        if (isEditMode) {
-            BasicTextField(
-                value = item.text,
-                onValueChange = onTextChange,
-                textStyle =
-                    MaterialTheme.typography.bodyLarge.copy(
-                        color =
-                            if (item.checked) {
-                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
-                            } else {
-                                MaterialTheme.colorScheme.onSurface
-                            },
-                        textDecoration = if (item.checked) TextDecoration.LineThrough else TextDecoration.None,
-                    ),
-                singleLine = true,
-                keyboardOptions =
-                    androidx.compose.foundation.text.KeyboardOptions(
-                        capitalization = androidx.compose.ui.text.input.KeyboardCapitalization.Sentences,
-                        imeAction = androidx.compose.ui.text.input.ImeAction.Next,
-                    ),
-                keyboardActions =
-                    androidx.compose.foundation.text.KeyboardActions(
-                        onNext = { onNext() },
-                    ),
-                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-                modifier =
-                    Modifier
-                        .weight(1f)
-                        .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier),
-                decorationBox = { inner ->
-                    if (item.text.isEmpty()) {
-                        Text(
-                            stringResource(R.string.edit_list_new_item_placeholder),
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f),
-                        )
-                    }
-                    inner()
-                },
-            )
-            RememberIconButton(onClick = onRemove) {
+            RememberIconButton(onClick = onToggle) {
                 RememberMaterialRoundedSymbol(
-                    name = "close",
+                    name = if (item.checked) "check_box" else "check_box_outline_blank",
                     size = 24.dp,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    tint = if (item.checked) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
                     weight = FontWeight.Medium,
                 )
             }
-        } else {
-            Text(
-                text = item.text.ifEmpty { stringResource(R.string.edit_list_new_item_placeholder) },
-                style =
-                    MaterialTheme.typography.bodyLarge.copy(
-                        color =
-                            if (item.checked) {
-                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
-                            } else if (item.text.isEmpty()) {
-                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f)
-                            } else {
-                                MaterialTheme.colorScheme.onSurface
-                            },
-                        textDecoration = if (item.checked) TextDecoration.LineThrough else TextDecoration.None,
-                    ),
-                modifier =
-                    if (onTextTap != null) {
+            if (isEditMode) {
+                BasicTextField(
+                    value = titleFieldValue,
+                    onValueChange = { newValue ->
+                        val oldText = titleFieldValue.text
+                        titleFieldValue = newValue
+                        if (newValue.text != oldText) {
+                            onTextChange(newValue.text)
+                        }
+                    },
+                    textStyle =
+                        MaterialTheme.typography.bodyLarge.copy(
+                            color =
+                                if (item.checked) {
+                                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                                } else {
+                                    MaterialTheme.colorScheme.onSurface
+                                },
+                            textDecoration = if (item.checked) TextDecoration.LineThrough else TextDecoration.None,
+                        ),
+                    singleLine = true,
+                    keyboardOptions =
+                        androidx.compose.foundation.text.KeyboardOptions(
+                            capitalization = androidx.compose.ui.text.input.KeyboardCapitalization.Sentences,
+                            imeAction = androidx.compose.ui.text.input.ImeAction.Next,
+                        ),
+                    keyboardActions =
+                        androidx.compose.foundation.text.KeyboardActions(
+                            onNext = { onNext() },
+                        ),
+                    cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                    modifier =
                         Modifier
                             .weight(1f)
-                            .tapSoundClickable(onClick = onTextTap)
-                    } else {
-                        Modifier.weight(1f)
+                            .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier),
+                    decorationBox = { inner ->
+                        if (item.text.isEmpty()) {
+                            Text(
+                                stringResource(R.string.edit_list_new_item_placeholder),
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f),
+                            )
+                        }
+                        inner()
                     },
-            )
+                )
+                if (showDetailsAffordance) {
+                    RememberIconButton(
+                        onClick = { detailsExpanded = !detailsExpanded },
+                        tooltipLabel = detailsToggleLabel,
+                    ) {
+                        RememberMaterialRoundedSymbol(
+                            name = if (detailsExpanded) "expand_less" else "notes",
+                            size = 22.dp,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            weight = FontWeight.Medium,
+                        )
+                    }
+                }
+                RememberIconButton(onClick = onRemove) {
+                    RememberMaterialRoundedSymbol(
+                        name = "close",
+                        size = 24.dp,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        weight = FontWeight.Medium,
+                    )
+                }
+            } else {
+                var titleLayout by remember(item.text) { mutableStateOf<TextLayoutResult?>(null) }
+                Text(
+                    text = item.text.ifEmpty { stringResource(R.string.edit_list_new_item_placeholder) },
+                    style =
+                        MaterialTheme.typography.bodyLarge.copy(
+                            color =
+                                if (item.checked) {
+                                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                                } else if (item.text.isEmpty()) {
+                                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f)
+                                } else {
+                                    MaterialTheme.colorScheme.onSurface
+                                },
+                            textDecoration = if (item.checked) TextDecoration.LineThrough else TextDecoration.None,
+                        ),
+                    onTextLayout = { titleLayout = it },
+                    modifier =
+                        if (onTextTap != null) {
+                            Modifier
+                                .weight(1f)
+                                .pointerInput(onTextTap, titleLayout) {
+                                    detectTapGestures { tapOffset ->
+                                        val offset =
+                                            if (item.text.isEmpty()) {
+                                                0
+                                            } else {
+                                                titleLayout?.getOffsetForPosition(tapOffset) ?: item.text.length
+                                            }
+                                        onTextTap(offset)
+                                    }
+                                }
+                        } else {
+                            Modifier.weight(1f)
+                        },
+                )
+                if (showDetailsAffordance) {
+                    RememberIconButton(
+                        onClick = { detailsExpanded = !detailsExpanded },
+                        tooltipLabel = detailsToggleLabel,
+                    ) {
+                        RememberMaterialRoundedSymbol(
+                            name = if (detailsExpanded) "expand_less" else "expand_more",
+                            size = 22.dp,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            weight = FontWeight.Medium,
+                        )
+                    }
+                }
+            }
+        }
+
+        if (detailsExpanded || (!isEditMode && detailPreview.isNotBlank())) {
+            val detailsStartPadding = (if (isEditMode && showDragHandle) 40.dp else 0.dp) + 40.dp
+            if (isEditMode) {
+                BasicTextField(
+                    value = detailsFieldValue,
+                    onValueChange = { newValue ->
+                        val oldText = detailsFieldValue.text
+                        detailsFieldValue = newValue
+                        if (newValue.text != oldText) {
+                            onDetailsChange(newValue.text)
+                        }
+                    },
+                    textStyle =
+                        MaterialTheme.typography.bodyMedium.copy(
+                            color =
+                                if (item.checked) {
+                                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
+                                } else {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                },
+                        ),
+                    keyboardOptions =
+                        androidx.compose.foundation.text.KeyboardOptions(
+                            capitalization = androidx.compose.ui.text.input.KeyboardCapitalization.Sentences,
+                            imeAction = androidx.compose.ui.text.input.ImeAction.Default,
+                        ),
+                    cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(start = detailsStartPadding, end = 48.dp, bottom = 8.dp)
+                            .then(if (detailsFocusRequester != null) Modifier.focusRequester(detailsFocusRequester) else Modifier),
+                    decorationBox = { inner ->
+                        if (item.details.isEmpty()) {
+                            Text(
+                                stringResource(R.string.edit_list_item_details_placeholder),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f),
+                            )
+                        }
+                        inner()
+                    },
+                )
+            } else {
+                var detailsLayout by remember(item.details) { mutableStateOf<TextLayoutResult?>(null) }
+                val detailsModifier =
+                    if (onDetailsTap != null) {
+                        Modifier.pointerInput(onDetailsTap, detailsLayout) {
+                            detectTapGestures { tapOffset ->
+                                val offset =
+                                    if (item.details.isEmpty()) {
+                                        0
+                                    } else {
+                                        detailsLayout?.getOffsetForPosition(tapOffset) ?: item.details.length
+                                    }
+                                detailsExpanded = true
+                                onDetailsTap(offset)
+                            }
+                        }
+                    } else if (detailsCanExpand) {
+                        Modifier.tapSoundClickable { detailsExpanded = !detailsExpanded }
+                    } else {
+                        Modifier
+                    }
+                Text(
+                    text = if (detailsExpanded) item.details else detailPreview,
+                    style =
+                        MaterialTheme.typography.bodyMedium.copy(
+                            color =
+                                if (item.checked) {
+                                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.42f)
+                                } else {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                },
+                        ),
+                    maxLines = if (detailsExpanded) Int.MAX_VALUE else 1,
+                    overflow = if (detailsExpanded) TextOverflow.Clip else TextOverflow.Ellipsis,
+                    onTextLayout = { detailsLayout = it },
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(start = detailsStartPadding, end = 48.dp, bottom = 8.dp)
+                            .then(detailsModifier),
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/dev/bikram/remember/ui/edit/EditListScreen.kt
+++ b/app/src/main/java/dev/bikram/remember/ui/edit/EditListScreen.kt
@@ -138,6 +138,8 @@ fun EditListScreen(
     val archived by vm.archived.collectAsStateWithLifecycle()
     val trashed by vm.trashed.collectAsStateWithLifecycle()
     val hasUnsavedChanges by vm.hasUnsavedChanges.collectAsStateWithLifecycle()
+    val createdAt by vm.createdAt.collectAsStateWithLifecycle()
+    val updatedAt by vm.updatedAt.collectAsStateWithLifecycle()
 
     var reminderPickerOpen by rememberSaveable { mutableStateOf(false) }
     var iconPickerOpen by rememberSaveable { mutableStateOf(false) }
@@ -796,6 +798,8 @@ fun EditListScreen(
                             notificationsAllowed = notificationsAllowed,
                             readOnly = readOnly,
                             starred = starred,
+                            createdAt = createdAt,
+                            updatedAt = updatedAt,
                             onOpenReminder = { reminderPickerOpen = true },
                             onImportanceChange = vm::setImportance,
                             onVisibilityChange = vm::setVisibility,

--- a/app/src/main/java/dev/bikram/remember/ui/edit/EditListScreen.kt
+++ b/app/src/main/java/dev/bikram/remember/ui/edit/EditListScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -74,7 +75,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
 import java.io.File
+
+private enum class FocusField { TITLE, DETAILS }
 
 @Composable
 fun EditListRoute(
@@ -170,29 +174,32 @@ fun EditListScreen(
 
     var isEditMode by remember(existing, forceEdit) { mutableStateOf(!existing || forceEdit) }
     var pendingFocusItemId by remember { mutableStateOf<Long?>(null) }
+    var pendingFocusField by remember { mutableStateOf(FocusField.TITLE) }
     var pendingTitleFocusOffset by remember { mutableStateOf<Int?>(null) }
+    var pendingItemTitleFocusOffset by remember { mutableStateOf<Int?>(null) }
+    var pendingItemDetailsFocusOffset by remember { mutableStateOf<Int?>(null) }
     LaunchedEffect(readOnly) {
         if (readOnly && isEditMode) isEditMode = false
     }
     LaunchedEffect(isEditMode) {
         if (!isEditMode) {
             pendingTitleFocusOffset = null
+            pendingItemTitleFocusOffset = null
+            pendingItemDetailsFocusOffset = null
         }
     }
 
     val keyboardController = LocalSoftwareKeyboardController.current
 
-    val lazyListStateForVisibility =
-        androidx.compose.foundation.lazy
-            .rememberLazyListState()
+    val lazyListState = androidx.compose.foundation.lazy.rememberLazyListState()
     var bottomBarVisible by remember { mutableStateOf(true) }
 
     // Force-show the bar whenever the list is scrolled to the very top. derivedStateOf is
     // cheaper than an observer because it only recomputes when the boolean transitions.
     val atTopOfContent by remember {
         derivedStateOf {
-            lazyListStateForVisibility.firstVisibleItemIndex == 0 &&
-                lazyListStateForVisibility.firstVisibleItemScrollOffset == 0
+            lazyListState.firstVisibleItemIndex == 0 &&
+                lazyListState.firstVisibleItemScrollOffset == 0
         }
     }
     LaunchedEffect(atTopOfContent) {
@@ -242,32 +249,90 @@ fun EditListScreen(
             deleteForeverCurrent = vm::deleteForeverCurrent,
             fireNotification = vm::fireNotification,
         )
-    val titleCollapseProgress by remember(lazyListStateForVisibility) {
+
+    val topAlphaMultiplier by remember(lazyListState) {
         derivedStateOf {
-            if (lazyListStateForVisibility.firstVisibleItemIndex > 0) {
+            if (lazyListState.firstVisibleItemIndex > 0) {
                 1f
             } else {
-                val offsetPx = lazyListStateForVisibility.firstVisibleItemScrollOffset.toFloat()
+                val offsetPx = lazyListState.firstVisibleItemScrollOffset.toFloat()
+                val thresholdPx = with(density) { 24.dp.toPx() }
+                (offsetPx / thresholdPx).coerceIn(0f, 1f)
+            }
+        }
+    }
+
+    val titleCollapseProgress by remember(lazyListState) {
+        derivedStateOf {
+            if (lazyListState.firstVisibleItemIndex > 0) {
+                1f
+            } else {
+                val offsetPx = lazyListState.firstVisibleItemScrollOffset.toFloat()
                 val thresholdPx = with(density) { 72.dp.toPx() }
                 (offsetPx / thresholdPx).coerceIn(0f, 1f)
             }
         }
     }
 
-    // Edit mode replaces the action bar: the list's inline "Add item" and the top-bar Save
-    // action take over, and the keyboard toolbar stays on the bottom unobstructed. Stacking
-    // the shelf action bar under the keyboard would look like a layout bug. IME visibility
-    // still gates it so the bar slides out when the keyboard appears.
-    val actionBarVisible = bottomBarVisible && !isEditMode && !imeVisible
+    val blurMod =
+        blurStyle?.applyToFullBleedLayer(topAlphaMultiplier = topAlphaMultiplier)
+            ?: Modifier
 
-    // Save path for the top-bar Save icon (only visible while in edit mode): flips edit
-    // mode off AND asks the route-level callback to flush the VM and flash the toast so
-    // users get feedback that their Save tap did something beyond dismissing the toolbar.
+    // Save on back press.
+    androidx.activity.compose.BackHandler(onBack = editorActions.saveAndBack)
+
+    val (completedItems, activeItems) = items.partition { it.checked }
+    val activeParents = activeItems.associateBy { it.localId }
+    val checkedParents = completedItems.associateBy { it.localId }
+    val activeEntries = remember(items) { buildActiveEntries(activeItems, activeParents, checkedParents) }
+    val completedEntries = remember(items) { buildCompletedEntries(completedItems, activeParents, checkedParents) }
+
+    var draggingParentLocalId by remember { mutableStateOf<Long?>(null) }
+    val visibleActiveEntries = remember(activeEntries, draggingParentLocalId) {
+        if (draggingParentLocalId == null) {
+            activeEntries
+        } else {
+            activeEntries.filter { entry ->
+                when (entry) {
+                    is ActiveEntry.Ghost -> entry.header.realParentLocalId != draggingParentLocalId
+                    is ActiveEntry.Row -> entry.item.localId == draggingParentLocalId || entry.item.parentLocalId != draggingParentLocalId
+                }
+            }
+        }
+    }
+    val visibleCompletedEntries = remember(completedEntries, draggingParentLocalId) {
+        if (draggingParentLocalId == null) {
+            completedEntries
+        } else {
+            completedEntries.filter { entry ->
+                when (entry) {
+                    is CompletedEntry.Ghost -> entry.header.realParentLocalId != draggingParentLocalId
+                    is CompletedEntry.Row -> entry.item.parentLocalId != draggingParentLocalId
+                }
+            }
+        }
+    }
+
+    val titleFocusRequesters = remember { androidx.compose.runtime.mutableStateMapOf<Long, FocusRequester>() }
+    val detailsFocusRequesters = remember { androidx.compose.runtime.mutableStateMapOf<Long, FocusRequester>() }
+
+    LaunchedEffect(pendingFocusItemId, isEditMode) {
+        if (isEditMode && pendingFocusItemId != null) {
+            delay(80)
+            val requester = if (pendingFocusField == FocusField.DETAILS) {
+                detailsFocusRequesters[pendingFocusItemId]
+            } else {
+                titleFocusRequesters[pendingFocusItemId]
+            }
+            requester?.requestFocus()
+            pendingFocusItemId = null
+        }
+    }
+
     val saveAndExitEditMode: () -> Unit = {
         isEditMode = false
         editorActions.saveAndShowToast()
     }
-    androidx.activity.compose.BackHandler(onBack = editorActions.saveAndBack)
 
     val adaptiveNoteThemes = LocalThemeState.current.adaptiveNoteThemes
     val imageDerivedColors =
@@ -276,6 +341,8 @@ fun EditListScreen(
             cacheRevision = pictureRevision,
         )
     val imageResolution = rememberImageDerivedColorScheme(imageDerivedColors)
+    var showChecked by rememberSaveable { mutableStateOf(true) }
+
     NoteAdaptiveTheme(imageResolution) {
         Box(Modifier.fillMaxSize()) {
             if (imageResolution != null) NotePageBackground(colorScheme = imageResolution.backgroundScheme)
@@ -290,7 +357,7 @@ fun EditListScreen(
                         title = title,
                         titlePlaceholder = titlePlaceholder,
                         iconKey = iconKey,
-                        existing = existing,
+                        existing = existing || persistedForToolbar,
                         isEditMode = isEditMode,
                         readOnly = readOnly,
                         hasUnsavedChanges = hasUnsavedChanges,
@@ -304,15 +371,16 @@ fun EditListScreen(
                         onTitleFocusOffsetConsumed = {
                             pendingTitleFocusOffset = null
                         },
-                        onOpenIcon = { iconPickerOpen = true },
-                        onSave = saveAndExitEditMode,
-                        showEditableWhenTitleEmpty = true,
+                        onTitleFocusChanged = { /* unused */ },
                         titleCollapseProgress = titleCollapseProgress,
+                        onSave = saveAndExitEditMode,
+                        onOpenIcon = { iconPickerOpen = true },
                     )
                 },
                 bottomBar = {
+                    val actionBarVisible = bottomBarVisible && !isEditMode && !imeVisible
                     EditorBottomBarSlot(
-                        isEditMode = isEditMode,
+                        isEditMode = false,
                         actionBarVisible = actionBarVisible,
                         actionContent = {
                             NoteActionBottomBarContent(
@@ -321,9 +389,9 @@ fun EditListScreen(
                                 isEditMode = isEditMode,
                                 starred = starred,
                                 completed = completed,
-                                // Action bar is hidden while isEditMode, so this callback only fires from
-                                // view mode - always turning edit mode ON. Save is owned by the top bar.
-                                onToggleEdit = { if (!isEditMode) isEditMode = true else saveAndExitEditMode() },
+                                onToggleEdit = {
+                                    if (!isEditMode) isEditMode = true else saveAndExitEditMode()
+                                },
                                 onToggleStar = { vm.toggleStar() },
                                 onToggleCompleted = {
                                     appScope.launch { vm.toggleCompleted() }
@@ -334,132 +402,16 @@ fun EditListScreen(
                                 onTrash = editorActions.trashAndBack,
                                 onRestore = editorActions.restore,
                                 onDeleteForever = { deleteForeverConfirmOpen = true },
-                                showEditAction = false,
+                                showEditAction = true,
                             )
                         },
                     )
                 },
             ) { padding ->
-                val topAlphaMultiplier by remember(lazyListStateForVisibility) {
-                    derivedStateOf {
-                        if (lazyListStateForVisibility.firstVisibleItemIndex > 0) {
-                            1f
-                        } else {
-                            val offsetPx = lazyListStateForVisibility.firstVisibleItemScrollOffset.toFloat()
-                            val thresholdPx = with(density) { 24.dp.toPx() }
-                            (offsetPx / thresholdPx).coerceIn(0f, 1f)
-                        }
-                    }
-                }
-                val blurMod =
-                    blurStyle?.applyToFullBleedLayer(topAlphaMultiplier = topAlphaMultiplier)
-                        ?: Modifier
-                val focusRequesters = remember { mutableMapOf<Long, FocusRequester>() }
-                var draggingParentLocalId by remember { mutableStateOf<Long?>(null) }
-                LaunchedEffect(isEditMode, pendingFocusItemId, readOnly) {
-                    val itemId = pendingFocusItemId
-                    if (isEditMode && itemId != null && !readOnly) {
-                        delay(80)
-                        focusRequesters[itemId]?.requestFocus()
-                        keyboardController?.show()
-                        pendingFocusItemId = null
-                    }
-                }
-
-                // ---------------------------------------------------------------------------------
-                // Compose the two weighted sublists per the spec:
-                //   activeList    = items.filter { !it.isChecked }.sortedBy { it.sortOrder }
-                //   completedList = items.filter {  it.isChecked }.sortedBy { it.sortOrder }
-                //
-                // The completed list is additionally augmented with "ghost parent" headers: when a
-                // checked child's real parent is still in the active section we synthesise a read-only
-                // header row above that child's group so the context isn't lost.
-                // ---------------------------------------------------------------------------------
-                val activeList =
-                    remember(items) {
-                        items.filter { !it.checked }.sortedBy { it.sortOrder }
-                    }
-                val completedItems =
-                    remember(items) {
-                        items.filter { it.checked }.sortedBy { it.sortOrder }
-                    }
-                val activeParentLookup =
-                    remember(activeList) {
-                        activeList.filter { it.depth == 0 }.associateBy { it.localId }
-                    }
-                val checkedParentLookup =
-                    remember(completedItems) {
-                        completedItems.filter { it.depth == 0 }.associateBy { it.localId }
-                    }
-                val completedEntries: List<CompletedEntry> =
-                    remember(completedItems, activeParentLookup, checkedParentLookup) {
-                        buildCompletedEntries(
-                            completedItems = completedItems,
-                            activeParents = activeParentLookup,
-                            checkedParents = checkedParentLookup,
-                        )
-                    }
-                // Mirror of completedEntries for the active half: synthesises a ghost parent header when a
-                // child is unchecked but its real parent is still in the completed section. This keeps the
-                // parent context visible when the user unchecks a single child out of a cascade-checked
-                // group (the user's bug report: "tap B2 to uncheck it, only B2 moves back to unchecked
-                // section, without a parent above it").
-                val activeEntries: List<ActiveEntry> =
-                    remember(activeList, activeParentLookup, checkedParentLookup) {
-                        buildActiveEntries(
-                            activeItems = activeList,
-                            activeParents = activeParentLookup,
-                            checkedParents = checkedParentLookup,
-                        )
-                    }
-                val visibleActiveEntries =
-                    remember(activeEntries, draggingParentLocalId) {
-                        val parentLocalId = draggingParentLocalId
-                        if (parentLocalId == null) {
-                            activeEntries
-                        } else {
-                            activeEntries.filterNot { entry ->
-                                when (entry) {
-                                    is ActiveEntry.Ghost -> true
-                                    is ActiveEntry.Row -> entry.item.depth == 1
-                                }
-                            }
-                        }
-                    }
-                val visibleCompletedEntries =
-                    remember(completedEntries, draggingParentLocalId) {
-                        val parentLocalId = draggingParentLocalId
-                        if (parentLocalId == null) {
-                            completedEntries
-                        } else {
-                            completedEntries.filterNot { entry ->
-                                when (entry) {
-                                    is CompletedEntry.Ghost -> entry.header.realParentLocalId == parentLocalId
-                                    is CompletedEntry.Row -> entry.item.parentLocalId == parentLocalId
-                                }
-                            }
-                        }
-                    }
-                val activeIds =
-                    remember(activeList, draggingParentLocalId) {
-                        val parentLocalId = draggingParentLocalId
-                        if (parentLocalId == null) {
-                            activeList.map { item -> item.localId }
-                        } else {
-                            activeList
-                                .filter { item -> item.depth == 0 }
-                                .map { item -> item.localId }
-                        }
-                    }
-                val completedRowIds = remember(completedItems) { completedItems.map { it.localId } }
-
-                var showChecked by rememberSaveable { mutableStateOf(true) }
-
-                val lazyListState = lazyListStateForVisibility
+                val activeIds = activeEntries.filterIsInstance<ActiveEntry.Row>().map { it.item.localId }
+                val completedRowIds = completedEntries.filterIsInstance<CompletedEntry.Row>().map { it.item.localId }
                 val reorderState =
-                    sh.calvin.reorderable.rememberReorderableLazyListState(lazyListState) { from, to ->
-                        // Keys are the EditableItem.localId for both active rows and completed rows. Ghost
-                        // headers are keyed with a synthetic "ghost-<parentId>" string so their drags are
+                    rememberReorderableLazyListState(lazyListState) { from, to ->
                         // ignored here. We only reorder within the matching sublist (no cross-section drags).
                         val fromId = from.key as? Long ?: return@rememberReorderableLazyListState
                         val toId = to.key as? Long ?: return@rememberReorderableLazyListState
@@ -587,22 +539,33 @@ fun EditListScreen(
                                             }
                                         }
                                     }
-                                    val focusRequester = remember(item.localId) { FocusRequester() }
-                                    DisposableEffect(item.localId, focusRequester) {
-                                        focusRequesters[item.localId] = focusRequester
+                                    val titleFocusRequester = remember(item.localId) { FocusRequester() }
+                                    val detailsFocusRequester = remember(item.localId) { FocusRequester() }
+                                    DisposableEffect(item.localId, titleFocusRequester, detailsFocusRequester) {
+                                        titleFocusRequesters[item.localId] = titleFocusRequester
+                                        detailsFocusRequesters[item.localId] = detailsFocusRequester
                                         onDispose {
-                                            if (focusRequesters[item.localId] === focusRequester) {
-                                                focusRequesters.remove(item.localId)
+                                            if (titleFocusRequesters[item.localId] === titleFocusRequester) {
+                                                titleFocusRequesters.remove(item.localId)
+                                            }
+                                            if (detailsFocusRequesters[item.localId] === detailsFocusRequester) {
+                                                detailsFocusRequesters.remove(item.localId)
                                             }
                                         }
                                     }
                                     ChecklistRow(
                                         item = item,
                                         isEditMode = isEditMode && !readOnly,
-                                        focusRequester = focusRequester,
+                                        focusRequester = titleFocusRequester,
+                                        detailsFocusRequester = detailsFocusRequester,
+                                        initialTitleSelection = if (pendingFocusItemId == item.localId) pendingItemTitleFocusOffset else null,
+                                        initialDetailsSelection = if (pendingFocusItemId == item.localId) pendingItemDetailsFocusOffset else null,
+                                        onTitleFocusOffsetConsumed = { pendingItemTitleFocusOffset = null },
+                                        onDetailsFocusOffsetConsumed = { pendingItemDetailsFocusOffset = null },
                                         isDragging = isDragging,
                                         dragHandleModifier = if (readOnly) Modifier else Modifier.draggableHandle(),
                                         onTextChange = if (readOnly) ({ _ -> }) else ({ vm.updateItemText(item.localId, it) }),
+                                        onDetailsChange = if (readOnly) ({ _ -> }) else ({ vm.updateItemDetails(item.localId, it) }),
                                         onToggle = if (readOnly) ({}) else ({ vm.toggleChecked(item.localId) }),
                                         onRemove = if (readOnly) ({}) else ({ vm.removeItem(item.localId) }),
                                         onNext =
@@ -612,6 +575,7 @@ fun EditListScreen(
                                                 (
                                                     {
                                                         pendingFocusItemId = vm.addItemAfter(item.localId)
+                                                        pendingFocusField = FocusField.TITLE
                                                         isEditMode = true
                                                     }
                                                 )
@@ -620,8 +584,21 @@ fun EditListScreen(
                                             if (readOnly) {
                                                 null
                                             } else {
-                                                {
+                                                { offset ->
                                                     pendingFocusItemId = item.localId
+                                                    pendingFocusField = FocusField.TITLE
+                                                    pendingItemTitleFocusOffset = offset
+                                                    isEditMode = true
+                                                }
+                                            },
+                                        onDetailsTap =
+                                            if (readOnly) {
+                                                null
+                                            } else {
+                                                { offset ->
+                                                    pendingFocusItemId = item.localId
+                                                    pendingFocusField = FocusField.DETAILS
+                                                    pendingItemDetailsFocusOffset = offset
                                                     isEditMode = true
                                                 }
                                             },
@@ -631,14 +608,6 @@ fun EditListScreen(
                                             } else {
                                                 (
                                                     { deltaDepth ->
-                                                        // deltaDepth = +1 means user dragged right (indent); -1 means
-                                                        // user dragged left (outdent). We delegate both to the
-                                                        // ViewModel so the anchor lookup runs on the freshest
-                                                        // in-memory list. Doing the lookup here was buggy: the
-                                                        // gesture lives inside a pointerInput(item.localId, depth)
-                                                        // block whose captured `activeList` does NOT refresh when
-                                                        // siblings are reordered, so swiping right after a drag
-                                                        // picked the wrong prior top-level row as the anchor.
                                                         if (deltaDepth > 0) {
                                                             vm.indent(item.localId)
                                                         } else if (deltaDepth < 0) {
@@ -664,6 +633,7 @@ fun EditListScreen(
                                             placementSpec = reducedMotionAwareSpec(MaterialTheme.motionScheme.slowSpatialSpec()),
                                         ).tapSoundClickable {
                                             pendingFocusItemId = vm.addItem()
+                                            pendingFocusField = FocusField.TITLE
                                             isEditMode = true
                                         }.padding(vertical = 14.dp),
                             ) {
@@ -735,28 +705,35 @@ fun EditListScreen(
                                                 ),
                                         )
                                     is CompletedEntry.Row -> {
-                                        // Checked rows are NOT wrapped in ReorderableItem: Google Keep
-                                        // freezes the order of checked items and we mirror that. The
-                                        // item sort order in completed is implicit (most-recently
-                                        // checked last, siblings grouped under their ghost parent).
                                         val item = entry.item
-                                        val focusRequester = remember(item.localId) { FocusRequester() }
-                                        DisposableEffect(item.localId, focusRequester) {
-                                            focusRequesters[item.localId] = focusRequester
+                                        val titleFocusRequester = remember(item.localId) { FocusRequester() }
+                                        val detailsFocusRequester = remember(item.localId) { FocusRequester() }
+                                        DisposableEffect(item.localId, titleFocusRequester, detailsFocusRequester) {
+                                            titleFocusRequesters[item.localId] = titleFocusRequester
+                                            detailsFocusRequesters[item.localId] = detailsFocusRequester
                                             onDispose {
-                                                if (focusRequesters[item.localId] === focusRequester) {
-                                                    focusRequesters.remove(item.localId)
+                                                if (titleFocusRequesters[item.localId] === titleFocusRequester) {
+                                                    titleFocusRequesters.remove(item.localId)
+                                                }
+                                                if (detailsFocusRequesters[item.localId] === detailsFocusRequester) {
+                                                    detailsFocusRequesters.remove(item.localId)
                                                 }
                                             }
                                         }
                                         ChecklistRow(
                                             item = item,
                                             isEditMode = isEditMode && !readOnly,
-                                            focusRequester = focusRequester,
+                                            focusRequester = titleFocusRequester,
+                                            detailsFocusRequester = detailsFocusRequester,
+                                            initialTitleSelection = if (pendingFocusItemId == item.localId) pendingItemTitleFocusOffset else null,
+                                            initialDetailsSelection = if (pendingFocusItemId == item.localId) pendingItemDetailsFocusOffset else null,
+                                            onTitleFocusOffsetConsumed = { pendingItemTitleFocusOffset = null },
+                                            onDetailsFocusOffsetConsumed = { pendingItemDetailsFocusOffset = null },
                                             isDragging = false,
                                             dragHandleModifier = Modifier,
                                             showDragHandle = false,
                                             onTextChange = if (readOnly) ({ _ -> }) else ({ vm.updateItemText(item.localId, it) }),
+                                            onDetailsChange = if (readOnly) ({ _ -> }) else ({ vm.updateItemDetails(item.localId, it) }),
                                             onToggle = if (readOnly) ({}) else ({ vm.toggleChecked(item.localId) }),
                                             onRemove = if (readOnly) ({}) else ({ vm.removeItem(item.localId) }),
                                             onNext =
@@ -766,6 +743,7 @@ fun EditListScreen(
                                                     (
                                                         {
                                                             pendingFocusItemId = vm.addItemAfter(item.localId)
+                                                            pendingFocusField = FocusField.TITLE
                                                             isEditMode = true
                                                         }
                                                     )
@@ -774,8 +752,21 @@ fun EditListScreen(
                                                 if (readOnly) {
                                                     null
                                                 } else {
-                                                    {
+                                                    { offset ->
                                                         pendingFocusItemId = item.localId
+                                                        pendingFocusField = FocusField.TITLE
+                                                        pendingItemTitleFocusOffset = offset
+                                                        isEditMode = true
+                                                    }
+                                                },
+                                            onDetailsTap =
+                                                if (readOnly) {
+                                                    null
+                                                } else {
+                                                    { offset ->
+                                                        pendingFocusItemId = item.localId
+                                                        pendingFocusField = FocusField.DETAILS
+                                                        pendingItemDetailsFocusOffset = offset
                                                         isEditMode = true
                                                     }
                                                 },

--- a/app/src/main/java/dev/bikram/remember/ui/edit/EditListViewModel.kt
+++ b/app/src/main/java/dev/bikram/remember/ui/edit/EditListViewModel.kt
@@ -96,6 +96,12 @@ class EditListViewModel
         private val _attachments = MutableStateFlow<List<NoteAttachmentEntity>>(emptyList())
         val attachments: StateFlow<List<NoteAttachmentEntity>> = _attachments.asStateFlow()
 
+        private val _createdAt = MutableStateFlow<Long?>(null)
+        val createdAt: StateFlow<Long?> = _createdAt.asStateFlow()
+
+        private val _updatedAt = MutableStateFlow<Long?>(null)
+        val updatedAt: StateFlow<Long?> = _updatedAt.asStateFlow()
+
         /**
          * Mirrors the underlying note's archived / trashed shelf. The edit screen uses these to
          * flip into read-only mode and swap the bottom-bar action set. New lists always start on
@@ -153,6 +159,8 @@ class EditListViewModel
                     _archived.value = n.archived
                     _trashed.value = n.trashed
                     _completed.value = n.completedAt != null
+                    _createdAt.value = n.createdAt
+                    _updatedAt.value = n.updatedAt
                     _items.value =
                         existing.items
                             .map {
@@ -179,6 +187,8 @@ class EditListViewModel
                         if (_trashed.value != n.trashed) _trashed.value = n.trashed
                         val isCompleted = n.completedAt != null
                         if (_completed.value != isCompleted) _completed.value = isCompleted
+                        if (_createdAt.value != n.createdAt) _createdAt.value = n.createdAt
+                        if (_updatedAt.value != n.updatedAt) _updatedAt.value = n.updatedAt
                     }
                 }
             }
@@ -197,6 +207,7 @@ class EditListViewModel
             } else {
                 repository.markCompleted(id)
             }
+            syncTimestamps()
         }
 
         fun setTitle(v: String) {
@@ -742,6 +753,10 @@ class EditListViewModel
                     val savedList = repository.get(newId)
                     originalNote = savedList?.note
                     originalItems = savedList?.items ?: emptyList()
+                    savedList?.note?.let { note ->
+                        _createdAt.value = note.createdAt
+                        _updatedAt.value = note.updatedAt
+                    }
 
                     return@withLock {
                         repository.moveToTrash(newId)
@@ -763,6 +778,10 @@ class EditListViewModel
                     val savedList = repository.get(id)
                     originalNote = savedList?.note
                     originalItems = savedList?.items ?: emptyList()
+                    savedList?.note?.let { note ->
+                        _createdAt.value = note.createdAt
+                        _updatedAt.value = note.updatedAt
+                    }
 
                     if (old != null) {
                         return@withLock {
@@ -805,6 +824,17 @@ class EditListViewModel
             }
         }
 
+        private fun syncTimestamps() {
+            val id = loadedId ?: return
+            viewModelScope.launch {
+                val cur = repository.get(id)?.note
+                if (cur != null) {
+                    _createdAt.value = cur.createdAt
+                    _updatedAt.value = cur.updatedAt
+                }
+            }
+        }
+
         suspend fun trashCurrent() {
             persistence.withLock {
                 val id = loadedId ?: return@withLock
@@ -813,6 +843,7 @@ class EditListViewModel
                 _trashed.value = true
                 _archived.value = false
             }
+            syncTimestamps()
         }
 
         /** Flip the list onto the archive shelf. Saves any in-flight edits first. */
@@ -825,6 +856,7 @@ class EditListViewModel
                 _trashed.value = false
                 persistence.clearDirty()
             }
+            syncTimestamps()
         }
 
         suspend fun unarchiveCurrent() {
@@ -835,6 +867,7 @@ class EditListViewModel
                 _trashed.value = false
                 persistence.clearDirty()
             }
+            syncTimestamps()
         }
 
         suspend fun restoreFromTrashCurrent() {
@@ -845,6 +878,7 @@ class EditListViewModel
                 _archived.value = false
                 persistence.clearDirty()
             }
+            syncTimestamps()
         }
 
         suspend fun fireNotification(

--- a/app/src/main/java/dev/bikram/remember/ui/edit/EditListViewModel.kt
+++ b/app/src/main/java/dev/bikram/remember/ui/edit/EditListViewModel.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.bikram.remember.data.AppMediaStorage
 import dev.bikram.remember.data.ChecklistItemEntity
@@ -14,6 +15,7 @@ import dev.bikram.remember.data.NoteOptions
 import dev.bikram.remember.data.NoteRepository
 import dev.bikram.remember.data.RecurrenceRule
 import dev.bikram.remember.data.RememberReservedTags
+import dev.bikram.remember.di.SettingsDependenciesEntryPoint
 import dev.bikram.remember.domain.checklist.ChecklistEditResult
 import dev.bikram.remember.domain.checklist.ChecklistEditor
 import dev.bikram.remember.domain.checklist.EditableItem
@@ -27,8 +29,6 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import dev.bikram.remember.data.Visibility as NoteVisibility
-import dagger.hilt.android.EntryPointAccessors
-import dev.bikram.remember.di.SettingsDependenciesEntryPoint
 
 @HiltViewModel
 class EditListViewModel
@@ -159,6 +159,7 @@ class EditListViewModel
                                 EditableItem(
                                     localId = it.id,
                                     text = it.text,
+                                    details = it.details,
                                     checked = it.checked,
                                     sortOrder = it.sortOrder,
                                     parentLocalId = it.parentId,
@@ -328,6 +329,7 @@ class EditListViewModel
                 EditableItem(
                     localId = localId,
                     text = "",
+                    details = "",
                     checked = false,
                     sortOrder = max + 1.0,
                     parentLocalId = null,
@@ -355,6 +357,17 @@ class EditListViewModel
             _items.value =
                 _items.value.map {
                     if (it.localId == localId) it.copy(text = text) else it
+                }
+            markDirty()
+        }
+
+        fun updateItemDetails(
+            localId: Long,
+            details: String,
+        ) {
+            _items.value =
+                _items.value.map {
+                    if (it.localId == localId) it.copy(details = details) else it
                 }
             markDirty()
         }
@@ -625,6 +638,7 @@ class EditListViewModel
                     id = 0,
                     noteId = id,
                     text = item.text,
+                    details = item.details,
                     checked = item.checked,
                     sortOrder = item.sortOrder,
                     parentId = null,
@@ -645,6 +659,7 @@ class EditListViewModel
                     dev.bikram.remember.data.PersistableChecklistItem(
                         localKey = item.localId,
                         text = item.text,
+                        details = item.details,
                         checked = item.checked,
                         sortOrder = item.sortOrder,
                         parentLocalKey = item.parentLocalId,
@@ -685,6 +700,7 @@ class EditListViewModel
                     val c = nowSorted[i]
                     val o = oldSorted[i]
                     if (c.text != o.text) return true
+                    if (c.details != o.details) return true
                     if (c.checked != o.checked) return true
                     if (c.sortOrder != o.sortOrder) return true
                     if (c.depth != o.depth) return true
@@ -716,13 +732,10 @@ class EditListViewModel
                     // Creation still goes through createList which assigns sortOrder itself. If the
                     // user pre-composed hierarchy/checked state in the draft, we re-run updateList
                     // immediately afterwards with the real persistable payload.
-                    val newId = repository.createList(finalTitle, 0, nonEmpty.map { it.text }, currentOptions())
+                    val newId = repository.createListWithItems(finalTitle, 0, persistable, currentOptions())
                     loadedId = newId
                     syncHasPersistedRow()
                     if (t.isBlank()) _title.value = finalTitle
-                    if (persistable.any { it.checked || it.parentLocalKey != null || it.depth > 0 }) {
-                        repository.updateList(newId, finalTitle, 0, persistable, currentOptions())
-                    }
                     if (_starred.value) repository.setStarred(newId, true)
                     persistence.clearDirtyIfUnchanged(epochAtWrite)
 
@@ -762,6 +775,7 @@ class EditListViewModel
                                         dev.bikram.remember.data.PersistableChecklistItem(
                                             localKey = it.id,
                                             text = it.text,
+                                            details = it.details,
                                             checked = it.checked,
                                             sortOrder = it.sortOrder,
                                             parentLocalKey = it.parentId,
@@ -840,10 +854,12 @@ class EditListViewModel
             saveIfNeeded(untitledName)
             val id = loadedId ?: return
             val noteWithItems = repository.get(id) ?: return
-            val reminderPrefs = EntryPointAccessors.fromApplication(
-                context.applicationContext,
-                SettingsDependenciesEntryPoint::class.java,
-            ).reminderPrefs()
+            val settingsDependencies =
+                EntryPointAccessors.fromApplication(
+                    context.applicationContext,
+                    SettingsDependenciesEntryPoint::class.java,
+                )
+            val reminderPrefs = settingsDependencies.reminderPrefs()
             val keepUntilDone = reminderPrefs.snapshot().keepReminderNotificationsUntilDone
             dev.bikram.remember.reminders.ReminderReceiver.showNotification(
                 context = context,

--- a/app/src/main/java/dev/bikram/remember/ui/edit/EditNoteEditorChunks.kt
+++ b/app/src/main/java/dev/bikram/remember/ui/edit/EditNoteEditorChunks.kt
@@ -751,6 +751,8 @@ private fun OptionsPanelSection(
     val tags by vm.tags.collectAsStateWithLifecycle()
     val attachments by vm.attachments.collectAsStateWithLifecycle()
     val starred by vm.starred.collectAsStateWithLifecycle()
+    val createdAt by vm.createdAt.collectAsStateWithLifecycle()
+    val updatedAt by vm.updatedAt.collectAsStateWithLifecycle()
 
     EditorOptionsPanel(
         reminderAt = reminderAt,
@@ -764,6 +766,8 @@ private fun OptionsPanelSection(
         notificationsAllowed = notificationsAllowed,
         readOnly = readOnly,
         starred = starred,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
         onOpenReminder = onOpenReminder,
         onImportanceChange = vm::setImportance,
         onVisibilityChange = vm::setVisibility,

--- a/app/src/main/java/dev/bikram/remember/ui/edit/EditNoteViewModel.kt
+++ b/app/src/main/java/dev/bikram/remember/ui/edit/EditNoteViewModel.kt
@@ -107,6 +107,12 @@ class EditNoteViewModel
         private val _attachments = MutableStateFlow<List<NoteAttachmentEntity>>(emptyList())
         val attachments: StateFlow<List<NoteAttachmentEntity>> = _attachments.asStateFlow()
 
+        private val _createdAt = MutableStateFlow<Long?>(null)
+        val createdAt: StateFlow<Long?> = _createdAt.asStateFlow()
+
+        private val _updatedAt = MutableStateFlow<Long?>(null)
+        val updatedAt: StateFlow<Long?> = _updatedAt.asStateFlow()
+
         /**
          * Mirrors the underlying note's archived / trashed shelf. Used by the edit screen to flip
          * into read-only mode and swap the bottom-bar action set. New notes always start on the
@@ -171,6 +177,8 @@ class EditNoteViewModel
                             _archived.value = n.archived
                             _trashed.value = n.trashed
                             _completed.value = n.completedAt != null
+                            _createdAt.value = n.createdAt
+                            _updatedAt.value = n.updatedAt
                         }
                     } finally {
                         // Leave loading when the load finishes: missing row, success, or thrown from get().
@@ -194,6 +202,8 @@ class EditNoteViewModel
                         if (_trashed.value != n.trashed) _trashed.value = n.trashed
                         val isCompleted = n.completedAt != null
                         if (_completed.value != isCompleted) _completed.value = isCompleted
+                        if (_createdAt.value != n.createdAt) _createdAt.value = n.createdAt
+                        if (_updatedAt.value != n.updatedAt) _updatedAt.value = n.updatedAt
                     }
                 }
             }
@@ -473,7 +483,12 @@ class EditNoteViewModel
                     if (_starred.value) repository.setStarred(newId, true)
                     persistence.clearDirtyIfUnchanged(epochAtWrite)
 
-                    originalNote = repository.get(newId)?.note
+                    val savedNote = repository.get(newId)?.note
+                    originalNote = savedNote
+                    if (savedNote != null) {
+                        _createdAt.value = savedNote.createdAt
+                        _updatedAt.value = savedNote.updatedAt
+                    }
 
                     return@withLock {
                         repository.moveToTrash(newId)
@@ -490,7 +505,12 @@ class EditNoteViewModel
                     persistence.clearDirtyIfUnchanged(epochAtWrite)
 
                     val old = originalNote
-                    originalNote = repository.get(id)?.note
+                    val savedNote = repository.get(id)?.note
+                    originalNote = savedNote
+                    if (savedNote != null) {
+                        _createdAt.value = savedNote.createdAt
+                        _updatedAt.value = savedNote.updatedAt
+                    }
 
                     if (old != null) {
                         return@withLock {
@@ -522,6 +542,17 @@ class EditNoteViewModel
             }
         }
 
+        private fun syncTimestamps() {
+            val id = loadedId ?: return
+            viewModelScope.launch {
+                val cur = repository.get(id)?.note
+                if (cur != null) {
+                    _createdAt.value = cur.createdAt
+                    _updatedAt.value = cur.updatedAt
+                }
+            }
+        }
+
         suspend fun trashCurrent() {
             persistence.withLock {
                 val id = loadedId ?: return@withLock
@@ -530,6 +561,7 @@ class EditNoteViewModel
                 _trashed.value = true
                 _archived.value = false
             }
+            syncTimestamps()
         }
 
         /**
@@ -546,6 +578,7 @@ class EditNoteViewModel
             } else {
                 repository.markCompleted(id)
             }
+            syncTimestamps()
         }
 
         /** Flip the note to the archive shelf after saving any in-flight edits. */
@@ -559,6 +592,7 @@ class EditNoteViewModel
                 _trashed.value = false
                 persistence.clearDirty()
             }
+            syncTimestamps()
         }
 
         suspend fun unarchiveCurrent() {
@@ -569,6 +603,7 @@ class EditNoteViewModel
                 _trashed.value = false
                 persistence.clearDirty()
             }
+            syncTimestamps()
         }
 
         suspend fun restoreFromTrashCurrent() {
@@ -579,6 +614,7 @@ class EditNoteViewModel
                 _archived.value = false
                 persistence.clearDirty()
             }
+            syncTimestamps()
         }
 
         /**

--- a/app/src/main/java/dev/bikram/remember/ui/edit/EditorOptionsHost.kt
+++ b/app/src/main/java/dev/bikram/remember/ui/edit/EditorOptionsHost.kt
@@ -36,6 +36,8 @@ fun EditorOptionsPanel(
     notificationsAllowed: Boolean,
     readOnly: Boolean,
     starred: Boolean,
+    createdAt: Long?,
+    updatedAt: Long?,
     onOpenReminder: () -> Unit,
     onImportanceChange: (Importance) -> Unit,
     onVisibilityChange: (NoteVisibility) -> Unit,
@@ -77,6 +79,8 @@ fun EditorOptionsPanel(
             },
         readOnly = readOnly,
         starred = starred,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
     )
 }
 

--- a/app/src/main/java/dev/bikram/remember/ui/edit/OptionsPanel.kt
+++ b/app/src/main/java/dev/bikram/remember/ui/edit/OptionsPanel.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
@@ -53,6 +54,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.core.graphics.drawable.toBitmap
 import dev.bikram.remember.R
 import dev.bikram.remember.data.ActionType
@@ -109,6 +111,8 @@ fun OptionsPanel(
     // wash on the panel surface plus a tilted watermark star at the top-end. Keeps the
     // starred cue consistent when the user opens a starred note or list into the editor.
     starred: Boolean = false,
+    createdAt: Long? = null,
+    updatedAt: Long? = null,
 ) {
     var behaviorOpen by rememberSaveable { mutableStateOf(false) }
     val context = LocalContext.current
@@ -271,6 +275,44 @@ fun OptionsPanel(
                             onClick = onOpenAttachments,
                             modifier = Modifier.weight(1f),
                         )
+                    }
+                }
+                if (createdAt != null && createdAt > 0L) {
+                    Spacer(Modifier.height(6.dp))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 2.dp),
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        val createdFormatted = remember(createdAt) {
+                            DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT).format(Date(createdAt))
+                        }
+                        Text(
+                            text = stringResource(R.string.options_created, createdFormatted),
+                            style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
+                        )
+                        if (updatedAt != null && updatedAt > 0L) {
+                            Text(
+                                text = "·",
+                                style = MaterialTheme.typography.labelSmall.copy(
+                                    fontSize = 12.sp,
+                                    fontWeight = FontWeight.Bold
+                                ),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
+                                modifier = Modifier.padding(horizontal = 6.dp),
+                            )
+                            val updatedFormatted = remember(updatedAt) {
+                                DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT).format(Date(updatedAt))
+                            }
+                            Text(
+                                text = stringResource(R.string.options_updated, updatedFormatted),
+                                style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,6 +195,7 @@
     </plurals>
     <string name="edit_list_add_item">Add item</string>
     <string name="edit_list_new_item_placeholder">New item</string>
+    <string name="edit_list_item_details_placeholder">Add details</string>
     <string name="rt_text_to_display">Text to display</string>
     <string name="rt_url_hint" tools:ignore="TypographyEllipsis">URL (e.g. https://...)</string>
     <string name="rt_h1">H1</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -398,6 +398,8 @@
     <string name="options_picture_none">No picture</string>
     <string name="options_picture_attached">Attached</string>
     <string name="options_attachments">Attachments</string>
+    <string name="options_created">Created: %1$s</string>
+    <string name="options_updated">Updated: %1$s</string>
     <plurals name="options_tags_more_count">
         <item quantity="one">+%1$d more</item>
         <item quantity="other">+%1$d more</item>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,18 @@
+## v1.0.3: Checklist item notes
+
+### ✨ New features
+
+- Add notes to individual checklist items.
+- Imported Google Tasks lists now keep task notes with their matching checklist items.
+- `Created` and `Updated` timestamps are now shown at the bottom of every note / checklist.
+
+### 🧾 Misc
+
+- Backups and restores now preserve checklist item notes.
+- Existing checklist data upgrades cleanly with support for item notes.
+
+---
+
 ## v1.0.2: Launch of **Remember**
 
 ### ✨ Features


### PR DESCRIPTION
## Summary

Adds per-checklist-item notes/details across Remember's list editor. 

### ✨ New Features

- Add notes/details to individual checklist items, with an inline `Add details` affordance in the list editor.
- Support viewing, expanding, editing, and cursor-focused tap editing for checklist item titles and details.
- Added a "footnote" style timestaps at the bottom of options panel

### 🚀 Improved Features

- Split checklist display into active items and a collapsible checked-items section.
- Preserve parent/child context across active and checked sections with synthetic parent headers.

### ✅ Bug Fixes

- Preserve checklist item details during backup export and restore.
- Add a Room migration for the new checklist item details column.

### 🧩 Others

- Bump the backup schema version to 3.
- Bump the Room database version to 3 and add the exported schema snapshot.
- Add the `Add details` string resource.
- No test files were added or changed in this branch diff.