### PR TITLE
Use locale-aware date/time and 24h setting

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,8 +72,8 @@ extensions.configure<ApplicationExtension>("android") {
         applicationId = rememberApplicationId
         minSdk = 31
         targetSdk = 37
-        versionCode = 103
-        versionName = "1.0.3"
+        versionCode = 104
+        versionName = "1.0.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }
     }

--- a/app/src/main/java/dev/bikram/remember/ui/edit/OptionsPanel.kt
+++ b/app/src/main/java/dev/bikram/remember/ui/edit/OptionsPanel.kt
@@ -286,8 +286,10 @@ fun OptionsPanel(
                         horizontalArrangement = Arrangement.Center,
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        val createdFormatted = remember(createdAt) {
-                            DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT).format(Date(createdAt))
+                        val createdFormatted = remember(createdAt, context) {
+                            val createdDate = Date(createdAt)
+                            android.text.format.DateFormat.getMediumDateFormat(context).format(createdDate) + " " +
+                                    android.text.format.DateFormat.getTimeFormat(context).format(createdDate)
                         }
                         Text(
                             text = stringResource(R.string.options_created, createdFormatted),
@@ -304,8 +306,10 @@ fun OptionsPanel(
                                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
                                 modifier = Modifier.padding(horizontal = 6.dp),
                             )
-                            val updatedFormatted = remember(updatedAt) {
-                                DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT).format(Date(updatedAt))
+                            val updatedFormatted = remember(updatedAt, context) {
+                                val updatedDate = Date(updatedAt)
+                                android.text.format.DateFormat.getMediumDateFormat(context).format(updatedDate) + " " +
+                                        android.text.format.DateFormat.getTimeFormat(context).format(updatedDate)
                             }
                             Text(
                                 text = stringResource(R.string.options_updated, updatedFormatted),
@@ -486,7 +490,12 @@ private fun ReminderOptionSummary(
         )
         return
     }
-    val datePart = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT).format(Date(reminderAt))
+    val summaryContext = LocalContext.current
+    val datePart = remember(reminderAt, summaryContext) {
+        val reminderDate = Date(reminderAt)
+        android.text.format.DateFormat.getMediumDateFormat(summaryContext).format(reminderDate) + " " +
+                android.text.format.DateFormat.getTimeFormat(summaryContext).format(reminderDate)
+    }
     val rule = recurrence?.sanitized()
     val recurrenceLabel = rule?.let { compactRecurrenceLabel(it) }.orEmpty()
     if (recurrenceLabel.isEmpty()) {

--- a/app/src/main/java/dev/bikram/remember/ui/edit/ReminderPicker.kt
+++ b/app/src/main/java/dev/bikram/remember/ui/edit/ReminderPicker.kt
@@ -808,11 +808,12 @@ internal fun ReminderTimePickerDialog(
         properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
         key(initialHour, initialMinute) {
+            val pickerContext = LocalContext.current
             val timePickerState =
                 rememberTimePickerState(
                     initialHour = initialHour,
                     initialMinute = initialMinute,
-                    is24Hour = false,
+                    is24Hour = DateFormat.is24HourFormat(pickerContext),
                 )
             Surface(
                 shape = MaterialTheme.shapes.extraLarge,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.0.3: Checklist item notes
+## v1.0.4: Checklist item notes, time format
 
 ### ✨ New features
 
@@ -10,6 +10,7 @@
 
 - Backups and restores now preserve checklist item notes.
 - Existing checklist data upgrades cleanly with support for item notes.
+- App now follows system time format (12 hours / 24 hours)
 
 ---
 


### PR DESCRIPTION
Replace generic DateFormat.getDateTimeInstance usage with android.text.format.DateFormat.getMediumDateFormat and getTimeFormat (using LocalContext) for OptionsPanel and ReminderOptionSummary so dates/times respect device locale. Include context in remember keys to avoid stale formatting. Also set time picker is24Hour from DateFormat.is24HourFormat(context) in ReminderPicker to honor user 24-hour preference.