### PR TITLE
Adaptive mosaic columns & layout toggle

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,8 +73,8 @@ extensions.configure<ApplicationExtension>("android") {
         applicationId = rememberApplicationId
         minSdk = 31
         targetSdk = 37
-        versionCode = 110
-        versionName = "1.1.0"
+        versionCode = 111
+        versionName = "1.1.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,6 +65,7 @@
 
         <activity
             android:name=".MainActivity"
+            android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|smallestScreenSize"
             android:exported="true"
             android:launchMode="singleTask"
             android:theme="@style/Theme.Remember.Starting"

--- a/app/src/main/java/dev/bikram/remember/ui/common/AdaptiveLayout.kt
+++ b/app/src/main/java/dev/bikram/remember/ui/common/AdaptiveLayout.kt
@@ -19,6 +19,14 @@ import androidx.compose.ui.unit.dp
 /** Below this many dp of usable height in landscape, screens switch to space-saving layouts. */
 const val SMALL_LANDSCAPE_HEIGHT_DP = 480
 
+internal fun noteMosaicColumnCount(availableWidth: Dp): Int =
+    when {
+        availableWidth < 340.dp -> 1
+        availableWidth < 960.dp -> 2
+        availableWidth < 1280.dp -> 3
+        else -> 4
+    }
+
 @Composable
 @ReadOnlyComposable
 fun isLandscape(): Boolean = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE

--- a/app/src/main/java/dev/bikram/remember/ui/history/HistoryScreen.kt
+++ b/app/src/main/java/dev/bikram/remember/ui/history/HistoryScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -100,6 +101,7 @@ import dev.bikram.remember.ui.common.RememberMaterialRoundedSymbol
 import dev.bikram.remember.ui.common.bulkActionSnackbarMessage
 import dev.bikram.remember.ui.common.emptyStateSpacing
 import dev.bikram.remember.ui.common.isLandscape
+import dev.bikram.remember.ui.common.noteMosaicColumnCount
 import dev.bikram.remember.ui.common.rememberNotificationsAllowed
 import dev.bikram.remember.ui.components.EmptyArchiveIllustration
 import dev.bikram.remember.ui.components.EmptyTrashIllustration
@@ -671,45 +673,132 @@ fun HistoryRoute(
                             top = listTopPadding,
                             bottom = pillInset + 24.dp,
                         )
-                    if (noteLayoutMode == NoteLayoutMode.MOSAIC) {
-                        LazyVerticalStaggeredGrid(
-                            columns = StaggeredGridCells.Adaptive(180.dp),
-                            state = targetGridState,
-                            modifier =
-                                Modifier
-                                    .fillMaxSize()
-                                    .then(listBlurMod),
-                            contentPadding = contentPadding,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            verticalItemSpacing = 6.dp,
-                        ) {
-                            if (targetSection == HistorySection.TRASH) {
-                                item(
-                                    key = "retention_notice",
-                                    contentType = "retention",
-                                    span = StaggeredGridItemSpan.FullLine,
-                                ) {
-                                    RetentionNotice(
-                                        modifier =
-                                            Modifier
-                                                .fillMaxWidth()
-                                                .padding(
-                                                    top = HistoryTopBarBlurBelowExtra,
-                                                    bottom = 12.dp,
-                                                ),
-                                    )
+                    BoxWithConstraints(Modifier.fillMaxSize()) {
+                        val mosaicColumnCount = noteMosaicColumnCount(maxWidth)
+                        if (noteLayoutMode == NoteLayoutMode.MOSAIC && mosaicColumnCount > 1) {
+                            LazyVerticalStaggeredGrid(
+                                columns = StaggeredGridCells.Fixed(mosaicColumnCount),
+                                state = targetGridState,
+                                modifier =
+                                    Modifier
+                                        .fillMaxSize()
+                                        .then(listBlurMod),
+                                contentPadding = contentPadding,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                verticalItemSpacing = 6.dp,
+                            ) {
+                                if (targetSection == HistorySection.TRASH) {
+                                    item(
+                                        key = "retention_notice",
+                                        contentType = "retention",
+                                        span = StaggeredGridItemSpan.FullLine,
+                                    ) {
+                                        RetentionNotice(
+                                            modifier =
+                                                Modifier
+                                                    .fillMaxWidth()
+                                                    .padding(
+                                                        top = HistoryTopBarBlurBelowExtra,
+                                                        bottom = 12.dp,
+                                                    ),
+                                        )
+                                    }
+                                }
+                                targetRows.forEach { row ->
+                                    item(
+                                        key = row.card.id,
+                                        contentType =
+                                            if (targetSection == HistorySection.TRASH) {
+                                                "trashedRow"
+                                            } else {
+                                                "archivedRow"
+                                            },
+                                    ) {
+                                        val noteId = row.card.id
+                                        val isSelected = noteId in selectedIds
+                                        val isActiveInDetailPane = !inSelectionMode && activeNoteId == noteId
+                                        var cardBounds by remember { mutableStateOf<Rect?>(null) }
+                                        HistorySwipeCard(
+                                            model = row.card,
+                                            section = targetSection,
+                                            daysLeft =
+                                                vm
+                                                    .daysLeftInTrash(row.note)
+                                                    .takeIf { targetSection == HistorySection.TRASH },
+                                            onOpenNote = {
+                                                if (inSelectionMode) {
+                                                    vm.toggleSelection(noteId)
+                                                } else {
+                                                    onOpenNote(row.note, false)
+                                                }
+                                            },
+                                            onRestore = { vm.restore(row.note) },
+                                            onArchive = { vm.archiveFromTrash(row.note) },
+                                            onDeleteForever = { pendingDeleteForeverNote = row.note },
+                                            onUnarchive = { vm.unarchive(row.note) },
+                                            onMoveToTrash = { vm.moveArchivedToTrash(row.note) },
+                                            selected = isSelected,
+                                            activeInDetailPane = isActiveInDetailPane,
+                                            onLongClick = { vm.toggleSelection(noteId) },
+                                            swipeEnabled = !inSelectionMode,
+                                            reminderNotificationsAllowed = notificationsAllowed,
+                                            modifier =
+                                                Modifier.onGloballyPositioned { coordinates ->
+                                                    cardBounds = coordinates.boundsInRoot()
+                                                    if (revealedNoteCardId == noteId) {
+                                                        revealedNoteCardBounds = cardBounds
+                                                    }
+                                                },
+                                            revealKey = noteId,
+                                            activeRevealKey = revealedNoteCardId,
+                                            onRevealStarted = {
+                                                revealedNoteCardId = noteId
+                                                revealedNoteCardBounds = cardBounds
+                                            },
+                                            onRevealClosed = {
+                                                if (revealedNoteCardId == noteId) {
+                                                    revealedNoteCardId = null
+                                                }
+                                            },
+                                        )
+                                    }
                                 }
                             }
-                            targetRows.forEach { row ->
-                                item(
-                                    key = row.card.id,
-                                    contentType =
+                        } else {
+                            LazyColumn(
+                                state = targetListState,
+                                modifier =
+                                    Modifier
+                                        .fillMaxSize()
+                                        .then(listBlurMod),
+                                contentPadding = contentPadding,
+                                verticalArrangement = Arrangement.spacedBy(6.dp),
+                                userScrollEnabled = targetListScrollEnabled,
+                            ) {
+                                if (targetSection == HistorySection.TRASH) {
+                                    item(key = "retention_notice", contentType = "retention") {
+                                        RetentionNotice(
+                                            modifier =
+                                                Modifier
+                                                    .fillMaxWidth()
+                                                    .padding(
+                                                        top = HistoryTopBarBlurBelowExtra,
+                                                        bottom = 12.dp,
+                                                    ),
+                                        )
+                                    }
+                                }
+                                items(
+                                    items = targetRows,
+                                    key = { row -> row.card.id },
+                                    contentType = {
                                         if (targetSection == HistorySection.TRASH) {
                                             "trashedRow"
                                         } else {
                                             "archivedRow"
-                                        },
-                                ) {
+                                        }
+                                    },
+                                ) { row ->
                                     val noteId = row.card.id
                                     val isSelected = noteId in selectedIds
                                     val isActiveInDetailPane = !inSelectionMode && activeNoteId == noteId
@@ -758,90 +847,6 @@ fun HistoryRoute(
                                         },
                                     )
                                 }
-                            }
-                        }
-                    } else {
-                        LazyColumn(
-                            state = targetListState,
-                            modifier =
-                                Modifier
-                                    .fillMaxSize()
-                                    .then(listBlurMod),
-                            contentPadding = contentPadding,
-                            verticalArrangement = Arrangement.spacedBy(6.dp),
-                            userScrollEnabled = targetListScrollEnabled,
-                        ) {
-                            if (targetSection == HistorySection.TRASH) {
-                                item(key = "retention_notice", contentType = "retention") {
-                                    RetentionNotice(
-                                        modifier =
-                                            Modifier
-                                                .fillMaxWidth()
-                                                .padding(
-                                                    top = HistoryTopBarBlurBelowExtra,
-                                                    bottom = 12.dp,
-                                                ),
-                                    )
-                                }
-                            }
-                            items(
-                                items = targetRows,
-                                key = { row -> row.card.id },
-                                contentType = {
-                                    if (targetSection == HistorySection.TRASH) {
-                                        "trashedRow"
-                                    } else {
-                                        "archivedRow"
-                                    }
-                                },
-                            ) { row ->
-                                val noteId = row.card.id
-                                val isSelected = noteId in selectedIds
-                                val isActiveInDetailPane = !inSelectionMode && activeNoteId == noteId
-                                var cardBounds by remember { mutableStateOf<Rect?>(null) }
-                                HistorySwipeCard(
-                                    model = row.card,
-                                    section = targetSection,
-                                    daysLeft =
-                                        vm
-                                            .daysLeftInTrash(row.note)
-                                            .takeIf { targetSection == HistorySection.TRASH },
-                                    onOpenNote = {
-                                        if (inSelectionMode) {
-                                            vm.toggleSelection(noteId)
-                                        } else {
-                                            onOpenNote(row.note, false)
-                                        }
-                                    },
-                                    onRestore = { vm.restore(row.note) },
-                                    onArchive = { vm.archiveFromTrash(row.note) },
-                                    onDeleteForever = { pendingDeleteForeverNote = row.note },
-                                    onUnarchive = { vm.unarchive(row.note) },
-                                    onMoveToTrash = { vm.moveArchivedToTrash(row.note) },
-                                    selected = isSelected,
-                                    activeInDetailPane = isActiveInDetailPane,
-                                    onLongClick = { vm.toggleSelection(noteId) },
-                                    swipeEnabled = !inSelectionMode,
-                                    reminderNotificationsAllowed = notificationsAllowed,
-                                    modifier =
-                                        Modifier.onGloballyPositioned { coordinates ->
-                                            cardBounds = coordinates.boundsInRoot()
-                                            if (revealedNoteCardId == noteId) {
-                                                revealedNoteCardBounds = cardBounds
-                                            }
-                                        },
-                                    revealKey = noteId,
-                                    activeRevealKey = revealedNoteCardId,
-                                    onRevealStarted = {
-                                        revealedNoteCardId = noteId
-                                        revealedNoteCardBounds = cardBounds
-                                    },
-                                    onRevealClosed = {
-                                        if (revealedNoteCardId == noteId) {
-                                            revealedNoteCardId = null
-                                        }
-                                    },
-                                )
                             }
                         }
                     }

--- a/app/src/main/java/dev/bikram/remember/ui/home/HomeScreen.kt
+++ b/app/src/main/java/dev/bikram/remember/ui/home/HomeScreen.kt
@@ -83,6 +83,7 @@ import dev.bikram.remember.data.NotesFilter
 import dev.bikram.remember.data.ViewOptions
 import dev.bikram.remember.ui.common.RememberMaterialRoundedSymbol
 import dev.bikram.remember.ui.common.bulkActionSnackbarMessage
+import dev.bikram.remember.ui.common.noteMosaicColumnCount
 import dev.bikram.remember.ui.common.rememberNotificationsAllowed
 import dev.bikram.remember.ui.components.NoteCard
 import dev.bikram.remember.ui.components.NoteCardUiModel
@@ -347,7 +348,6 @@ fun HomeScreen(
         }
     }
     val displayedItems = state.items
-    val useMosaicLayout = state.viewOptions.noteLayoutMode == NoteLayoutMode.MOSAIC
     val visibleDisplayedItems by
         remember(displayedItems, collapsedSectionKeys) {
             derivedStateOf {
@@ -594,9 +594,18 @@ fun HomeScreen(
             // landscape panes. If the content is taller it simply grows and the list
             // scrolls; nothing is ever clipped.
             val emptyStateMinHeight = (maxHeight - topInset - bottomPadding).coerceAtLeast(0.dp)
+            val mosaicColumnCount = noteMosaicColumnCount(maxWidth)
+            val effectiveNoteLayoutMode =
+                if (state.viewOptions.noteLayoutMode == NoteLayoutMode.MOSAIC && mosaicColumnCount > 1) {
+                    NoteLayoutMode.MOSAIC
+                } else {
+                    NoteLayoutMode.LIST
+                }
+            val useMosaicLayout = effectiveNoteLayoutMode == NoteLayoutMode.MOSAIC
+            val layoutToggleEnabled = mosaicColumnCount > 1
             if (useMosaicLayout) {
                 LazyVerticalStaggeredGrid(
-                    columns = StaggeredGridCells.Adaptive(180.dp),
+                    columns = StaggeredGridCells.Fixed(mosaicColumnCount),
                     state = mosaicGridState,
                     modifier =
                         Modifier
@@ -1030,21 +1039,22 @@ fun HomeScreen(
                 contentAlignment = Alignment.TopEnd,
             ) {
                 // In pane mode (showSelectionActionBar = false) the detail pane owns
-                // Select all / Cancel selection, so the top-bar swap stays out entirely.
+                // Select all / Cancel selection, so only selection chrome stays out.
                 if (!state.inSelectionMode) {
                     SearchableTopBarTitle(
                         searchOpen = searchOpen,
                         requestSearchFocus = searchShouldRequestFocus,
                         query = state.filter.text,
-                        noteLayoutMode = state.viewOptions.noteLayoutMode,
-                        showLayoutToggle = showSelectionActionBar,
+                        noteLayoutMode = effectiveNoteLayoutMode,
+                        showLayoutToggle = true,
+                        layoutToggleEnabled = layoutToggleEnabled,
                         onQueryChange = onQueryChange,
                         onSearchFocusRequested = { searchShouldRequestFocus = false },
                         onToggleLayout = {
                             onViewOptionsChange(
                                 state.viewOptions.copy(
                                     noteLayoutMode =
-                                        if (state.viewOptions.noteLayoutMode == NoteLayoutMode.LIST) {
+                                        if (effectiveNoteLayoutMode == NoteLayoutMode.LIST) {
                                             NoteLayoutMode.MOSAIC
                                         } else {
                                             NoteLayoutMode.LIST

--- a/app/src/main/java/dev/bikram/remember/ui/home/HomeSearchComponents.kt
+++ b/app/src/main/java/dev/bikram/remember/ui/home/HomeSearchComponents.kt
@@ -90,6 +90,7 @@ internal fun SearchableTopBarTitle(
     query: String,
     noteLayoutMode: NoteLayoutMode,
     showLayoutToggle: Boolean,
+    layoutToggleEnabled: Boolean,
     onQueryChange: (String) -> Unit,
     onSearchFocusRequested: () -> Unit,
     onToggleLayout: () -> Unit,
@@ -173,6 +174,7 @@ internal fun SearchableTopBarTitle(
             RememberFilledTonalIconButton(
                 onClick = onToggleLayout,
                 modifier = Modifier.size(rememberResponsiveActionButtonSize()),
+                enabled = layoutToggleEnabled,
                 tooltipLabel = layoutToggleDescription,
             ) {
                 val layoutMorphProgress by animateFloatAsState(

--- a/app/src/test/java/dev/bikram/remember/ui/common/AdaptiveLayoutTest.kt
+++ b/app/src/test/java/dev/bikram/remember/ui/common/AdaptiveLayoutTest.kt
@@ -1,0 +1,19 @@
+package dev.bikram.remember.ui.common
+
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AdaptiveLayoutTest {
+    @Test
+    fun noteMosaicColumnCountUsesWidthBreakpoints() {
+        assertEquals(1, noteMosaicColumnCount(320.dp))
+        assertEquals(2, noteMosaicColumnCount(340.dp))
+        assertEquals(2, noteMosaicColumnCount(559.dp))
+        assertEquals(2, noteMosaicColumnCount(760.dp))
+        assertEquals(2, noteMosaicColumnCount(959.dp))
+        assertEquals(3, noteMosaicColumnCount(960.dp))
+        assertEquals(3, noteMosaicColumnCount(1279.dp))
+        assertEquals(4, noteMosaicColumnCount(1280.dp))
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.1.0: Landscape / tablet layout, grid view, multi-reminders
+## v1.1.1: Landscape / tablet layout, grid view, multi-reminders
 
 ### ✨ New Features
 - **Landscape and tablet support.** The app now adapts to landscape and larger screens — notes, history, and settings can show a side-by-side list-and-detail view.


### PR DESCRIPTION
## 🛠 Improved Features
- **Width-based grid columns.** New `noteMosaicColumnCount(width)` helper in `AdaptiveLayout.kt` returns a fixed column count by usable width — 1 below 340dp, 2 below 960dp, 3 below 1280dp, 4 beyond. Both `HomeScreen` and `HistoryScreen` now use `StaggeredGridCells.Fixed(mosaicColumnCount)` instead of `StaggeredGridCells.Adaptive(180.dp)`, giving predictable column counts across phone / landscape / tablet instead of letting cell width decide.
- **Graceful fallback on narrow windows.** When the available width only fits one column, the mosaic view falls back to the list layout (`effectiveNoteLayoutMode`), and the grid/list toggle stays visible but is shown disabled (`layoutToggleEnabled`) rather than being hidden — so the control's presence is consistent regardless of window size. The toggle is also now always rendered (previously gated on `showSelectionActionBar`/pane mode).
- **Smoother rotation.** `MainActivity` now declares `android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|smallestScreenSize"`, so the activity handles orientation/size changes itself instead of being recreated on every rotation — avoiding the recreate flash and preserving in-memory UI state when switching between portrait and landscape.

## 📦 Others
- Version 1.1.1 (versionCode 111), up from 1.1.0 (110); CHANGELOG header retitled v1.1.0 → v1.1.1.
- Added `AdaptiveLayoutTest.kt` — unit test asserting `noteMosaicColumnCount` returns 1/2/3/4 exactly at the 340 / 960 / 1280dp breakpoints.
- `HistoryScreen` mosaic branch wrapped in `BoxWithConstraints` to read `maxWidth` for the column-count decision; list and grid branches reordered accordingly (no behavior change beyond the fallback above).
- `SearchableTopBarTitle` gains a `layoutToggleEnabled` parameter threaded through from `HomeScreen`.
